### PR TITLE
I've integrated OpenAI (ChatGPT) alongside Gemini into the Flask app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Simple Gemini API Web Aggregator (Single AI)
+# Multi-AI Aggregator (Gemini & OpenAI)
 
-This application provides a simple web interface to query the Google Gemini API. You can enter a text prompt, and the application will display the response from the Gemini model.
+This application provides a simple web interface to query both the Google Gemini API and the OpenAI (ChatGPT) API with a single prompt. It then displays the responses from each AI side-by-side.
 
 ## Prerequisites
 
@@ -16,11 +16,21 @@ This application provides a simple web interface to query the Google Gemini API.
     # cd <repository_directory>
     ```
 
-2.  **Obtain a Google Gemini API Key:**
-    *   Go to [Google AI Studio](https://aistudio.google.com/apikey).
-    *   Sign in with your Google account if prompted.
-    *   Click on "Create API key in new project" or use an existing project to generate your API key.
-    *   Copy the generated API key. You will need it in step 4.
+2.  **Obtain API Keys:**
+    You will need API keys for both Google Gemini and OpenAI.
+
+    *   **Google Gemini API Key:**
+        *   Go to [Google AI Studio](https://aistudio.google.com/apikey).
+        *   Sign in with your Google account if prompted.
+        *   Click on "Create API key in new project" or use an existing project.
+        *   Copy the generated API key.
+
+    *   **OpenAI API Key:**
+        *   Go to [OpenAI Platform - API Keys](https://platform.openai.com/account/api-keys).
+        *   Sign up or log in to your OpenAI account.
+        *   Navigate to the API keys section and create a new secret key.
+        *   Copy the generated API key.
+        *   **Note on Free Tier:** Check OpenAI's current free tier offerings when you sign up. New accounts often receive free credits suitable for testing with models like `gpt-3.5-turbo`.
 
 3.  **Create a Python Virtual Environment (Recommended):**
     ```bash
@@ -37,35 +47,58 @@ This application provides a simple web interface to query the Google Gemini API.
     pip install -r requirements.txt
     ```
 
-5.  **Configure the API Key:**
-    *   Open the `gemini_client.py` file in a text editor.
-    *   Locate the line: `API_KEY = 'YOUR_API_KEY'`
-    *   Replace `'YOUR_API_KEY'` with the actual API key you obtained from Google AI Studio.
-    *   Save the `gemini_client.py` file.
-    *   **Note:** For better security in production applications, consider using environment variables or a secure secrets management solution for your API key. For this simple research app, direct editing is used for simplicity.
+5.  **Configure API Keys:**
+
+    *   **Gemini API Key:**
+        *   Open the `gemini_client.py` file in a text editor.
+        *   Locate the line: `API_KEY = 'YOUR_API_KEY'`
+        *   Replace `'YOUR_API_KEY'` with your actual Gemini API key.
+        *   Save the `gemini_client.py` file.
+
+    *   **OpenAI API Key:**
+        *   **Recommended Method (Environment Variable):**
+            Set an environment variable named `OPENAI_API_KEY` to your OpenAI API key. The `openai_client.py` script will automatically use it.
+            ```bash
+            # On macOS/Linux
+            # export OPENAI_API_KEY='your_openai_api_key_here' 
+            # (add this to your .bashrc or .zshrc for persistence)
+
+            # On Windows (PowerShell)
+            # $Env:OPENAI_API_KEY='your_openai_api_key_here' 
+            # (add to your PowerShell profile for persistence)
+            ```
+        *   **Alternative Method (Edit `openai_client.py`):**
+            If you don't set the environment variable, you can directly edit `openai_client.py`:
+            *   Open `openai_client.py`.
+            *   Locate the line: `OPENAI_API_KEY_DIRECT = 'YOUR_OPENAI_API_KEY'`
+            *   Replace `'YOUR_OPENAI_API_KEY'` with your actual OpenAI API key.
+            *   Save the `openai_client.py` file.
+
+    *   **Note on Security:** For simple local testing, editing the files or using environment variables is acceptable. For production, use more robust secret management.
 
 ## Running the Application
 
 1.  **Ensure your virtual environment is activated (if you created one).**
-
-2.  **Run the Flask web server:**
+2.  **Ensure API keys are configured as described above.**
+3.  **Run the Flask web server:**
     ```bash
     python app.py
     ```
 
-3.  **Open your web browser:**
-    Navigate to `http://127.0.0.1:5000/` (or the URL shown in your terminal, usually localhost on port 5000).
+4.  **Open your web browser:**
+    Navigate to `http://127.0.0.1:5000/` (or the URL shown in your terminal).
 
-4.  **Use the App:**
-    *   If you see a warning about the API key not being configured, double-check step 5 in the "Setup Instructions".
-    *   Enter your prompt in the text area.
-    *   Click "Get Response".
-    *   The response from Gemini will be displayed below the form.
+5.  **Use the App:**
+    *   The page will show the configuration status for both Gemini and OpenAI API keys.
+    *   Enter your common prompt in the text area.
+    *   Click "Get Responses from AIs".
+    *   Responses from both Gemini and OpenAI (if configured and successful) will be displayed.
 
 ## Project Structure
 
 *   `app.py`: The Flask web server application.
 *   `gemini_client.py`: Handles communication with the Google Gemini API.
+*   `openai_client.py`: Handles communication with the OpenAI API.
 *   `templates/index.html`: The HTML template for the web interface.
 *   `requirements.txt`: Lists the Python dependencies.
 *   `README.md`: This file.

--- a/app.py
+++ b/app.py
@@ -1,53 +1,79 @@
 from flask import Flask, render_template, request
-from gemini_client import get_gemini_response, API_KEY # Import API_KEY to check configuration
+import os
+
+# Import from our AI client modules
+from gemini_client import get_gemini_response, API_KEY as GEMINI_API_KEY, MODEL_NAME as GEMINI_MODEL_NAME
+from openai_client import get_openai_response, OPENAI_API_KEY_DIRECT, MODEL_NAME as OPENAI_MODEL_NAME
 
 app = Flask(__name__)
 
+def check_gemini_config():
+    return GEMINI_API_KEY != 'YOUR_API_KEY'
+
+def check_openai_config():
+    return os.getenv('OPENAI_API_KEY') is not None or OPENAI_API_KEY_DIRECT != 'YOUR_OPENAI_API_KEY'
+
 @app.route('/', methods=['GET'])
 def index():
-    api_key_configured = API_KEY != 'YOUR_API_KEY'
-    return render_template('index.html', api_key_not_configured=not api_key_configured)
+    gemini_configured = check_gemini_config()
+    openai_configured = check_openai_config()
+    return render_template('index.html', 
+                           gemini_configured=gemini_configured,
+                           openai_configured=openai_configured,
+                           gemini_model=GEMINI_MODEL_NAME,
+                           openai_model=OPENAI_MODEL_NAME)
 
 @app.route('/get_response', methods=['POST'])
 def get_response_route():
-    api_key_configured = API_KEY != 'YOUR_API_KEY'
-    if not api_key_configured:
-        return render_template('index.html', 
-                               error="API Key not configured on the server. Please ask the administrator to set it up.",
-                               api_key_not_configured=True)
-
+    gemini_configured = check_gemini_config()
+    openai_configured = check_openai_config()
+    
     prompt = request.form.get('prompt')
     if not prompt:
         return render_template('index.html', 
                                error="Prompt cannot be empty.", 
                                prompt_text=prompt,
-                               api_key_not_configured=False)
+                               gemini_configured=gemini_configured,
+                               openai_configured=openai_configured,
+                               gemini_model=GEMINI_MODEL_NAME,
+                               openai_model=OPENAI_MODEL_NAME)
 
-    # Call the function from gemini_client.py
-    gemini_response = get_gemini_response(prompt)
+    gemini_response_text = None
+    openai_response_text = None
+    error_messages = []
 
-    # Check if the response indicates an API key configuration error from the client script itself
-    if "Error: API_KEY has not been configured" in gemini_response:
-         return render_template('index.html',
-                               error=gemini_response, # Show the specific error from gemini_client
-                               prompt_text=prompt,
-                               api_key_not_configured=True) # Treat as not configured
-    elif "An error occurred:" in gemini_response: # General error from gemini_client
-        return render_template('index.html',
-                               error=gemini_response,
-                               prompt_text=prompt,
-                               api_key_not_configured=False)
-    
+    if not gemini_configured:
+        error_messages.append("Gemini API key not configured in gemini_client.py.")
+    else:
+        gemini_response_text = get_gemini_response(prompt)
+        if "Error:" in gemini_response_text or "An error occurred:" in gemini_response_text : # Check for errors from client
+            error_messages.append(f"Gemini: {gemini_response_text}")
+            # Potentially set gemini_response_text to None or keep error to display it
+            # For now, we'll let the error message be the response text for that AI
+
+    if not openai_configured:
+        error_messages.append("OpenAI API key not configured in openai_client.py or as ENV variable.")
+    else:
+        openai_response_text = get_openai_response(prompt) # Assumes openai_client handles its own key internally
+        if "Error:" in openai_response_text or "An unexpected error occurred with OpenAI:" in openai_response_text or "OpenAI AuthenticationError:" in openai_response_text or "OpenAI RateLimitError:" in openai_response_text or "OpenAI APIConnectionError:" in openai_response_text: # Check for errors from client
+            error_messages.append(f"OpenAI: {openai_response_text}")
+            # Potentially set openai_response_text to None
+
+    # Join error messages if any
+    final_error_message = " | ".join(error_messages) if error_messages else None
+        
     return render_template('index.html', 
-                           response=gemini_response, 
+                           gemini_response=gemini_response_text,
+                           openai_response=openai_response_text,
                            prompt_text=prompt,
-                           api_key_not_configured=False)
+                           error=final_error_message,
+                           gemini_configured=gemini_configured,
+                           openai_configured=openai_configured,
+                           gemini_model=GEMINI_MODEL_NAME,
+                           openai_model=OPENAI_MODEL_NAME)
 
 if __name__ == '__main__':
-    # Before running, ensure:
-    # 1. You have installed Flask: pip install Flask
-    # 2. You have configured your API_KEY in gemini_client.py
-    print("Starting Flask server...")
+    print("Starting Flask server for Multi-AI Aggregator...")
     print("Open your browser and go to http://127.0.0.1:5000/")
-    print("Make sure 'gemini_client.py' is in the same directory and API_KEY is set.")
-    app.run(debug=True) # debug=True is helpful for development
+    print("Ensure API keys are set in 'gemini_client.py' and 'openai_client.py' (or as OPENAI_API_KEY env var).")
+    app.run(debug=True)

--- a/openai_client.py
+++ b/openai_client.py
@@ -1,0 +1,91 @@
+import openai
+import os
+
+# --- Configuration ---
+# IMPORTANT: You need to set your OpenAI API key.
+# Option 1: Set it as an environment variable named OPENAI_API_KEY.
+#             The script will automatically pick it up. This is recommended.
+# Option 2: Replace 'YOUR_OPENAI_API_KEY' below with your actual key.
+#             This is simpler for this script but less secure for larger projects.
+# You can obtain an API key from: https://platform.openai.com/account/api-keys
+OPENAI_API_KEY_DIRECT = 'YOUR_OPENAI_API_KEY' # Replace if not using environment variable
+
+MODEL_NAME = 'gpt-3.5-turbo'
+
+def get_openai_response(prompt: str, api_key: str = None) -> str:
+    """
+    Sends a prompt to the OpenAI API (ChatGPT) and returns the text response.
+
+    Args:
+        prompt: The text prompt to send to the model.
+        api_key: Optional. Your OpenAI API key. If not provided,
+                 the function will try to use the OPENAI_API_KEY environment
+                 variable or the OPENAI_API_KEY_DIRECT variable set in this file.
+
+    Returns:
+        The model's text response, or an error message if something went wrong.
+    """
+    client = None
+    try:
+        if api_key:
+            client = openai.OpenAI(api_key=api_key)
+        elif os.getenv('OPENAI_API_KEY'):
+            client = openai.OpenAI() # Uses environment variable OPENAI_API_KEY
+        elif OPENAI_API_KEY_DIRECT != 'YOUR_OPENAI_API_KEY':
+            client = openai.OpenAI(api_key=OPENAI_API_KEY_DIRECT)
+        else:
+            return "Error: OpenAI API key not configured. Please set the OPENAI_API_KEY environment variable or update OPENAI_API_KEY_DIRECT in openai_client.py."
+
+        # Create a chat completion request
+        # For gpt-3.5-turbo and similar models, the input is a list of messages
+        response = client.chat.completions.create(
+            model=MODEL_NAME,
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": prompt}
+            ]
+        )
+        # The response structure for chat models provides choices, and the message content is nested.
+        if response.choices and len(response.choices) > 0:
+            return response.choices[0].message.content.strip()
+        else:
+            return "Error: No response received from OpenAI."
+
+    except openai.AuthenticationError:
+        return "OpenAI AuthenticationError: Incorrect API key or billing issue. Please check your OpenAI API key and account status."
+    except openai.RateLimitError:
+        return "OpenAI RateLimitError: You have exceeded your current quota. Please check your OpenAI plan and billing details."
+    except openai.APIConnectionError as e:
+        return f"OpenAI APIConnectionError: Could not connect to OpenAI. Details: {e}"
+    except Exception as e:
+        return f"An unexpected error occurred with OpenAI: {e}"
+
+if __name__ == '__main__':
+    print("Welcome to the OpenAI API Client!")
+    print("---------------------------------")
+    print("Important: Make sure you have configured your OpenAI API key.")
+    print("You can set it as an environment variable 'OPENAI_API_KEY' (recommended),")
+    print("or directly edit the 'OPENAI_API_KEY_DIRECT' variable in this script.")
+    print("Get an API key from https://platform.openai.com/account/api-keys")
+    print("---------------------------------")
+
+    # Check if key might be configured
+    configured_check = os.getenv('OPENAI_API_KEY') or OPENAI_API_KEY_DIRECT != 'YOUR_OPENAI_API_KEY'
+
+    if not configured_check:
+        print("Please configure your OpenAI API key before running.")
+    else:
+        print(f"Using model: {MODEL_NAME}")
+        print("\nThis script will now send a test prompt to the OpenAI API.")
+        
+        test_prompt = "What is the capital of France?"
+        print(f"\nSending prompt: \"{test_prompt}\"")
+        
+        # Get the response
+        api_response = get_openai_response(test_prompt)
+        
+        print("\nResponse from OpenAI (ChatGPT):")
+        print(api_response)
+
+        print("\n--- Test Complete ---")
+        print("You can now import the 'get_openai_response' function in your Flask app.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask>=2.0
 google-generativeai>=0.4
+openai>=1.0  # Or a recent appropriate version

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,49 +3,78 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Gemini AI Aggregator</title>
+    <title>Multi-AI Aggregator (Gemini & OpenAI)</title>
     <style>
-        body { font-family: sans-serif; margin: 20px; background-color: #f4f4f4; color: #333; }
-        .container { max-width: 800px; margin: auto; background-color: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
-        h1 { color: #444; text-align: center; }
-        textarea { width: 95%; padding: 10px; margin-bottom: 10px; border-radius: 4px; border: 1px solid #ddd; font-size: 16px; }
-        input[type="submit"] { background-color: #007bff; color: white; padding: 10px 20px; border: none; border-radius: 4px; cursor: pointer; font-size: 16px; }
+        body { font-family: sans-serif; margin: 20px; background-color: #f0f2f5; color: #333; }
+        .container { max-width: 900px; margin: auto; background-color: #fff; padding: 25px; border-radius: 10px; box-shadow: 0 2px 15px rgba(0,0,0,0.1); }
+        h1 { color: #333; text-align: center; margin-bottom: 20px; }
+        h2 { color: #444; margin-top: 30px; border-bottom: 1px solid #eee; padding-bottom: 5px;}
+        textarea { width: 95%; padding: 12px; margin-bottom: 15px; border-radius: 5px; border: 1px solid #ccc; font-size: 16px; resize: vertical; }
+        input[type="submit"] { background-color: #007bff; color: white; padding: 12px 25px; border: none; border-radius: 5px; cursor: pointer; font-size: 16px; transition: background-color 0.2s; }
         input[type="submit"]:hover { background-color: #0056b3; }
-        .response-area { margin-top: 20px; padding: 15px; background-color: #e9e9e9; border-radius: 4px; white-space: pre-wrap; /* Preserve line breaks */ }
-        .error { color: red; font-weight: bold; }
-        .api-key-warning { background-color: #fff3cd; color: #856404; border: 1px solid #ffeeba; padding: 10px; border-radius: 4px; margin-bottom: 15px; text-align: center;}
+        .response-container { display: flex; flex-wrap: wrap; gap: 20px; margin-top: 20px;}
+        .response-area { flex: 1; min-width: 300px; padding: 15px; background-color: #f9f9f9; border-radius: 5px; white-space: pre-wrap; /* Preserve line breaks */ border: 1px solid #e7e7e7;}
+        .response-area h3 { margin-top: 0; color: #555; font-size: 18px; }
+        .error-message { background-color: #ffebee; color: #c62828; border: 1px solid #ef9a9a; padding: 12px; border-radius: 5px; margin-bottom: 20px; text-align: center; white-space: pre-wrap;}
+        .config-status { background-color: #e7f3fe; color: #0d47a1; border: 1px solid #b3e5fc; padding: 10px; border-radius: 5px; margin-bottom: 15px; font-size: 0.9em;}
+        .config-status p { margin: 5px 0; }
+        .config-ok { color: #1e8e3e; }
+        .config-nok { color: #d93025; font-weight: bold;}
     </style>
 </head>
 <body>
     <div class="container">
-        <h1>Query Gemini API</h1>
+        <h1>Multi-AI Query</h1>
 
-        {% if api_key_not_configured %}
-        <div class="api-key-warning">
-            <strong>Warning:</strong> The Gemini API key is not configured on the server.
-            Please ensure <code>gemini_client.py</code> has the correct API key.
+        <div class="config-status">
+            <h4>API Configuration Status:</h4>
+            <p>Gemini ({{ gemini_model }}): 
+                {% if gemini_configured %}
+                    <span class="config-ok">Configured</span>
+                {% else %}
+                    <span class="config-nok">NOT CONFIGURED</span> (Edit <code>gemini_client.py</code>)
+                {% endif %}
+            </p>
+            <p>OpenAI ({{ openai_model }}): 
+                {% if openai_configured %}
+                    <span class="config-ok">Configured</span>
+                {% else %}
+                    <span class="config-nok">NOT CONFIGURED</span> (Edit <code>openai_client.py</code> or set <code>OPENAI_API_KEY</code> env var)
+                {% endif %}
+            </p>
+            {% if not gemini_configured or not openai_configured %}
+            <p class="config-nok">Responses may be incomplete if API keys are not set.</p>
+            {% endif %}
         </div>
-        {% endif %}
 
         <form action="/get_response" method="post">
-            <label for="prompt">Enter your prompt:</label><br>
-            <textarea name="prompt" id="prompt" rows="5" required>{{ prompt_text if prompt_text else '' }}</textarea><br>
-            <input type="submit" value="Get Response">
+            <label for="prompt">Enter your common prompt:</label><br>
+            <textarea name="prompt" id="prompt" rows="6" required>{{ prompt_text if prompt_text else '' }}</textarea><br>
+            <input type="submit" value="Get Responses from AIs">
         </form>
 
-        {% if response %}
-        <h2>Response from Gemini:</h2>
-        <div class="response-area">
-            {{ response }}
-        </div>
+        {% if error %}
+            <div class="error-message">
+                <strong>Errors:</strong><br>{{ error }}
+            </div>
         {% endif %}
 
-        {% if error %}
-        <h2>Error:</h2>
-        <div class="response-area error">
-            {{ error }}
+        <div class="response-container">
+            {% if gemini_response %}
+            <div class="response-area">
+                <h3>Gemini's Response ({{ gemini_model }}):</h3>
+                <p>{{ gemini_response }}</p>
+            </div>
+            {% endif %}
+
+            {% if openai_response %}
+            <div class="response-area">
+                <h3>OpenAI's Response ({{ openai_model }}):</h3>
+                <p>{{ openai_response }}</p>
+            </div>
+            {% endif %}
         </div>
-        {% endif %}
+
     </div>
 </body>
 </html>


### PR DESCRIPTION
This version allows you to send a single prompt to both Google Gemini and OpenAI (ChatGPT) and view their responses side-by-side.

Key changes:
- Added `openai_client.py` to handle OpenAI API interactions, including API key management (environment variable or direct edit) and error handling.
- Modified `app.py` to call both Gemini and OpenAI clients, collect their responses or errors, and pass them to the template.
- Updated `templates/index.html` to display API configuration status for both AIs and to render their responses in separate sections.
- Added `openai` to `requirements.txt`.
- Updated `README.md` with instructions for OpenAI API key setup and to reflect the multi-AI functionality.