### PR TITLE
I've integrated Anthropic Claude, completing the three-AI aggregator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Multi-AI Aggregator (Gemini & OpenAI)
+# Multi-AI Aggregator (Gemini, OpenAI & Anthropic Claude)
 
-This application provides a simple web interface to query both the Google Gemini API and the OpenAI (ChatGPT) API with a single prompt. It then displays the responses from each AI side-by-side.
+This application provides a simple web interface to query Google Gemini, OpenAI (ChatGPT), and Anthropic Claude APIs with a single prompt. It then displays the responses from each AI side-by-side.
 
 ## Prerequisites
 
@@ -17,32 +17,33 @@ This application provides a simple web interface to query both the Google Gemini
     ```
 
 2.  **Obtain API Keys:**
-    You will need API keys for both Google Gemini and OpenAI.
+    You will need API keys for Google Gemini, OpenAI, and Anthropic Claude.
 
     *   **Google Gemini API Key:**
         *   Go to [Google AI Studio](https://aistudio.google.com/apikey).
-        *   Sign in with your Google account if prompted.
-        *   Click on "Create API key in new project" or use an existing project.
-        *   Copy the generated API key.
+        *   Sign in and create/use a project to generate your API key.
+        *   Copy the key.
 
     *   **OpenAI API Key:**
         *   Go to [OpenAI Platform - API Keys](https://platform.openai.com/account/api-keys).
-        *   Sign up or log in to your OpenAI account.
-        *   Navigate to the API keys section and create a new secret key.
-        *   Copy the generated API key.
-        *   **Note on Free Tier:** Check OpenAI's current free tier offerings when you sign up. New accounts often receive free credits suitable for testing with models like `gpt-3.5-turbo`.
+        *   Sign up/log in and create a new secret key.
+        *   Copy the key.
+        *   **Note on Free Tier (OpenAI):** Check OpenAI's current free tier/trial credit offerings.
+
+    *   **Anthropic Claude API Key:**
+        *   Go to the [Anthropic Console](https://console.anthropic.com/) and navigate to Account Settings -> API Keys (or similar path).
+        *   Sign up/log in and generate a new API key.
+        *   Copy the key.
+        *   **Note on Free Tier (Anthropic):** Check your Anthropic account dashboard for any initial free credits. The API is generally pay-as-you-go. We recommend using a Haiku model (e.g., `claude-3-haiku-20240307`) for cost-effectiveness.
 
 3.  **Create a Python Virtual Environment (Recommended):**
     ```bash
     python -m venv venv
-    # On Windows
-    # venv\Scripts\activate
-    # On macOS/Linux
-    # source venv/bin/activate
+    # On Windows: venv\Scripts\activate
+    # On macOS/Linux: source venv/bin/activate
     ```
 
 4.  **Install Dependencies:**
-    Install the required Python packages using the `requirements.txt` file:
     ```bash
     pip install -r requirements.txt
     ```
@@ -50,55 +51,43 @@ This application provides a simple web interface to query both the Google Gemini
 5.  **Configure API Keys:**
 
     *   **Gemini API Key:**
-        *   Open the `gemini_client.py` file in a text editor.
-        *   Locate the line: `API_KEY = 'YOUR_API_KEY'`
+        *   Edit `gemini_client.py`.
         *   Replace `'YOUR_API_KEY'` with your actual Gemini API key.
-        *   Save the `gemini_client.py` file.
 
     *   **OpenAI API Key:**
-        *   **Recommended Method (Environment Variable):**
-            Set an environment variable named `OPENAI_API_KEY` to your OpenAI API key. The `openai_client.py` script will automatically use it.
-            ```bash
-            # On macOS/Linux
-            # export OPENAI_API_KEY='your_openai_api_key_here' 
-            # (add this to your .bashrc or .zshrc for persistence)
+        *   **Recommended:** Set an environment variable `OPENAI_API_KEY` to your OpenAI API key.
+        *   **Alternative:** Edit `openai_client.py` and replace `'YOUR_OPENAI_API_KEY'` with your key.
 
-            # On Windows (PowerShell)
-            # $Env:OPENAI_API_KEY='your_openai_api_key_here' 
-            # (add to your PowerShell profile for persistence)
-            ```
-        *   **Alternative Method (Edit `openai_client.py`):**
-            If you don't set the environment variable, you can directly edit `openai_client.py`:
-            *   Open `openai_client.py`.
-            *   Locate the line: `OPENAI_API_KEY_DIRECT = 'YOUR_OPENAI_API_KEY'`
-            *   Replace `'YOUR_OPENAI_API_KEY'` with your actual OpenAI API key.
-            *   Save the `openai_client.py` file.
+    *   **Anthropic Claude API Key:**
+        *   **Recommended:** Set an environment variable `ANTHROPIC_API_KEY` to your Anthropic API key.
+        *   **Alternative:** Edit `claude_client.py` and replace `'YOUR_ANTHROPIC_API_KEY'` with your key.
 
-    *   **Note on Security:** For simple local testing, editing the files or using environment variables is acceptable. For production, use more robust secret management.
+    *   **Note on Security:** For local testing, these methods are acceptable. For production, use more secure secret management.
 
 ## Running the Application
 
-1.  **Ensure your virtual environment is activated (if you created one).**
-2.  **Ensure API keys are configured as described above.**
+1.  **Ensure your virtual environment is activated.**
+2.  **Ensure all three API keys are configured as described above.**
 3.  **Run the Flask web server:**
     ```bash
     python app.py
     ```
 
 4.  **Open your web browser:**
-    Navigate to `http://127.0.0.1:5000/` (or the URL shown in your terminal).
+    Navigate to `http://127.0.0.1:5000/`.
 
 5.  **Use the App:**
-    *   The page will show the configuration status for both Gemini and OpenAI API keys.
-    *   Enter your common prompt in the text area.
+    *   The page will show the configuration status for all three API keys.
+    *   Enter your common prompt.
     *   Click "Get Responses from AIs".
-    *   Responses from both Gemini and OpenAI (if configured and successful) will be displayed.
+    *   Responses from Gemini, OpenAI, and Claude (if configured and successful) will be displayed.
 
 ## Project Structure
 
-*   `app.py`: The Flask web server application.
-*   `gemini_client.py`: Handles communication with the Google Gemini API.
-*   `openai_client.py`: Handles communication with the OpenAI API.
-*   `templates/index.html`: The HTML template for the web interface.
-*   `requirements.txt`: Lists the Python dependencies.
+*   `app.py`: Flask web server.
+*   `gemini_client.py`: Client for Google Gemini API.
+*   `openai_client.py`: Client for OpenAI API.
+*   `claude_client.py`: Client for Anthropic Claude API.
+*   `templates/index.html`: HTML template for the UI.
+*   `requirements.txt`: Python dependencies.
 *   `README.md`: This file.

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import os
 # Import from our AI client modules
 from gemini_client import get_gemini_response, API_KEY as GEMINI_API_KEY, MODEL_NAME as GEMINI_MODEL_NAME
 from openai_client import get_openai_response, OPENAI_API_KEY_DIRECT, MODEL_NAME as OPENAI_MODEL_NAME
+from claude_client import get_claude_response, ANTHROPIC_API_KEY_DIRECT, MODEL_NAME as CLAUDE_MODEL_NAME
 
 app = Flask(__name__)
 
@@ -13,20 +14,27 @@ def check_gemini_config():
 def check_openai_config():
     return os.getenv('OPENAI_API_KEY') is not None or OPENAI_API_KEY_DIRECT != 'YOUR_OPENAI_API_KEY'
 
+def check_claude_config():
+    return os.getenv('ANTHROPIC_API_KEY') is not None or ANTHROPIC_API_KEY_DIRECT != 'YOUR_ANTHROPIC_API_KEY'
+
 @app.route('/', methods=['GET'])
 def index():
     gemini_configured = check_gemini_config()
     openai_configured = check_openai_config()
+    claude_configured = check_claude_config()
     return render_template('index.html', 
                            gemini_configured=gemini_configured,
                            openai_configured=openai_configured,
+                           claude_configured=claude_configured,
                            gemini_model=GEMINI_MODEL_NAME,
-                           openai_model=OPENAI_MODEL_NAME)
+                           openai_model=OPENAI_MODEL_NAME,
+                           claude_model=CLAUDE_MODEL_NAME)
 
 @app.route('/get_response', methods=['POST'])
 def get_response_route():
     gemini_configured = check_gemini_config()
     openai_configured = check_openai_config()
+    claude_configured = check_claude_config()
     
     prompt = request.form.get('prompt')
     if not prompt:
@@ -35,45 +43,57 @@ def get_response_route():
                                prompt_text=prompt,
                                gemini_configured=gemini_configured,
                                openai_configured=openai_configured,
+                               claude_configured=claude_configured,
                                gemini_model=GEMINI_MODEL_NAME,
-                               openai_model=OPENAI_MODEL_NAME)
+                               openai_model=OPENAI_MODEL_NAME,
+                               claude_model=CLAUDE_MODEL_NAME)
 
     gemini_response_text = None
     openai_response_text = None
+    claude_response_text = None
     error_messages = []
 
+    # Gemini
     if not gemini_configured:
         error_messages.append("Gemini API key not configured in gemini_client.py.")
     else:
         gemini_response_text = get_gemini_response(prompt)
-        if "Error:" in gemini_response_text or "An error occurred:" in gemini_response_text : # Check for errors from client
+        if "Error:" in gemini_response_text or "An error occurred:" in gemini_response_text:
             error_messages.append(f"Gemini: {gemini_response_text}")
-            # Potentially set gemini_response_text to None or keep error to display it
-            # For now, we'll let the error message be the response text for that AI
-
+    
+    # OpenAI
     if not openai_configured:
         error_messages.append("OpenAI API key not configured in openai_client.py or as ENV variable.")
     else:
-        openai_response_text = get_openai_response(prompt) # Assumes openai_client handles its own key internally
-        if "Error:" in openai_response_text or "An unexpected error occurred with OpenAI:" in openai_response_text or "OpenAI AuthenticationError:" in openai_response_text or "OpenAI RateLimitError:" in openai_response_text or "OpenAI APIConnectionError:" in openai_response_text: # Check for errors from client
+        openai_response_text = get_openai_response(prompt)
+        if "Error:" in openai_response_text or "An unexpected error occurred with OpenAI:" in openai_response_text or "OpenAI AuthenticationError:" in openai_response_text or "OpenAI RateLimitError:" in openai_response_text or "OpenAI APIConnectionError:" in openai_response_text:
             error_messages.append(f"OpenAI: {openai_response_text}")
-            # Potentially set openai_response_text to None
 
-    # Join error messages if any
+    # Claude
+    if not claude_configured:
+        error_messages.append("Anthropic Claude API key not configured in claude_client.py or as ENV variable.")
+    else:
+        claude_response_text = get_claude_response(prompt)
+        if "Error:" in claude_response_text or "An unexpected error occurred with Anthropic:" in claude_response_text or "Anthropic AuthenticationError:" in claude_response_text or "Anthropic RateLimitError:" in claude_response_text or "Anthropic APIConnectionError:" in claude_response_text :
+            error_messages.append(f"Claude: {claude_response_text}")
+
     final_error_message = " | ".join(error_messages) if error_messages else None
         
     return render_template('index.html', 
                            gemini_response=gemini_response_text,
                            openai_response=openai_response_text,
+                           claude_response=claude_response_text,
                            prompt_text=prompt,
                            error=final_error_message,
                            gemini_configured=gemini_configured,
                            openai_configured=openai_configured,
+                           claude_configured=claude_configured,
                            gemini_model=GEMINI_MODEL_NAME,
-                           openai_model=OPENAI_MODEL_NAME)
+                           openai_model=OPENAI_MODEL_NAME,
+                           claude_model=CLAUDE_MODEL_NAME)
 
 if __name__ == '__main__':
-    print("Starting Flask server for Multi-AI Aggregator...")
+    print("Starting Flask server for Multi-AI Aggregator (Gemini, OpenAI, Claude)...")
     print("Open your browser and go to http://127.0.0.1:5000/")
-    print("Ensure API keys are set in 'gemini_client.py' and 'openai_client.py' (or as OPENAI_API_KEY env var).")
+    print("Ensure API keys are set in 'gemini_client.py', 'openai_client.py' (or env var), and 'claude_client.py' (or env var).")
     app.run(debug=True)

--- a/claude_client.py
+++ b/claude_client.py
@@ -1,0 +1,94 @@
+import anthropic
+import os
+
+# --- Configuration ---
+# IMPORTANT: You need to set your Anthropic API key.
+# Option 1: Set it as an environment variable named ANTHROPIC_API_KEY.
+#             The script will automatically pick it up. This is recommended.
+# Option 2: Replace 'YOUR_ANTHROPIC_API_KEY' below with your actual key.
+# You can obtain an API key from: https://console.anthropic.com/account/keys
+ANTHROPIC_API_KEY_DIRECT = 'YOUR_ANTHROPIC_API_KEY' # Replace if not using environment variable
+
+# Using Claude 3 Haiku for cost-effectiveness and speed.
+MODEL_NAME = 'claude-3-haiku-20240307' 
+
+def get_claude_response(prompt: str, api_key: str = None) -> str:
+    """
+    Sends a prompt to the Anthropic Claude API and returns the text response.
+
+    Args:
+        prompt: The text prompt to send to the model.
+        api_key: Optional. Your Anthropic API key. If not provided,
+                 the function will try to use the ANTHROPIC_API_KEY environment
+                 variable or the ANTHROPIC_API_KEY_DIRECT variable set in this file.
+
+    Returns:
+        The model's text response, or an error message if something went wrong.
+    """
+    client = None
+    try:
+        if api_key:
+            client = anthropic.Anthropic(api_key=api_key)
+        elif os.getenv('ANTHROPIC_API_KEY'):
+            client = anthropic.Anthropic() # Uses environment variable ANTHROPIC_API_KEY
+        elif ANTHROPIC_API_KEY_DIRECT != 'YOUR_ANTHROPIC_API_KEY':
+            client = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY_DIRECT)
+        else:
+            return "Error: Anthropic API key not configured. Please set the ANTHROPIC_API_KEY environment variable or update ANTHROPIC_API_KEY_DIRECT in claude_client.py."
+
+        # Create a message request
+        response = client.messages.create(
+            model=MODEL_NAME,
+            max_tokens=2048, # Max tokens for the response
+            messages=[
+                {"role": "user", "content": prompt}
+            ]
+        )
+        
+        # The response structure for Claude API provides content as a list of blocks.
+        # We need to extract the text from the first text block if available.
+        if response.content and isinstance(response.content, list) and len(response.content) > 0:
+            first_block = response.content[0]
+            if hasattr(first_block, 'text'):
+                return first_block.text
+            else:
+                return "Error: No text content found in Claude's response block."
+        else:
+            return "Error: No content received from Claude or unexpected format."
+
+    except anthropic.AuthenticationError as e:
+        return f"Anthropic AuthenticationError: {e.body.get('error', {}).get('message', 'Please check your Anthropic API key and account status.')}"
+    except anthropic.RateLimitError as e:
+        return f"Anthropic RateLimitError: {e.body.get('error', {}).get('message', 'You have exceeded your current quota. Please check your Anthropic plan and billing details.')}"
+    except anthropic.APIConnectionError as e:
+        return f"Anthropic APIConnectionError: Could not connect to Anthropic. Details: {e}"
+    except Exception as e:
+        return f"An unexpected error occurred with Anthropic: {e}"
+
+if __name__ == '__main__':
+    print("Welcome to the Anthropic Claude API Client!")
+    print("-----------------------------------------")
+    print("Important: Make sure you have configured your Anthropic API key.")
+    print("You can set it as an environment variable 'ANTHROPIC_API_KEY' (recommended),")
+    print("or directly edit the 'ANTHROPIC_API_KEY_DIRECT' variable in this script.")
+    print(f"Get an API key from https://console.anthropic.com/account/keys")
+    print("-----------------------------------------")
+
+    configured_check = os.getenv('ANTHROPIC_API_KEY') or ANTHROPIC_API_KEY_DIRECT != 'YOUR_ANTHROPIC_API_KEY'
+
+    if not configured_check:
+        print("Please configure your Anthropic API key before running.")
+    else:
+        print(f"Using model: {MODEL_NAME}")
+        print("\nThis script will now send a test prompt to the Anthropic Claude API.")
+        
+        test_prompt = "Explain the concept of 'emergence' in complex systems in a few sentences."
+        print(f"\nSending prompt: \"{test_prompt}\"")
+        
+        api_response = get_claude_response(test_prompt)
+        
+        print("\nResponse from Anthropic Claude:")
+        print(api_response)
+
+        print("\n--- Test Complete ---")
+        print("You can now import the 'get_claude_response' function in your Flask app.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask>=2.0
 google-generativeai>=0.4
-openai>=1.0  # Or a recent appropriate version
+openai>=1.0
+anthropic>=0.20 # Or a recent appropriate version

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,17 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Multi-AI Aggregator (Gemini & OpenAI)</title>
+    <title>Multi-AI Aggregator (Gemini, OpenAI & Claude)</title>
     <style>
         body { font-family: sans-serif; margin: 20px; background-color: #f0f2f5; color: #333; }
-        .container { max-width: 900px; margin: auto; background-color: #fff; padding: 25px; border-radius: 10px; box-shadow: 0 2px 15px rgba(0,0,0,0.1); }
+        .container { max-width: 1200px; /* Increased width for three columns */ margin: auto; background-color: #fff; padding: 25px; border-radius: 10px; box-shadow: 0 2px 15px rgba(0,0,0,0.1); }
         h1 { color: #333; text-align: center; margin-bottom: 20px; }
         h2 { color: #444; margin-top: 30px; border-bottom: 1px solid #eee; padding-bottom: 5px;}
-        textarea { width: 95%; padding: 12px; margin-bottom: 15px; border-radius: 5px; border: 1px solid #ccc; font-size: 16px; resize: vertical; }
+        textarea { width: 97%; /* Adjusted for padding */ padding: 12px; margin-bottom: 15px; border-radius: 5px; border: 1px solid #ccc; font-size: 16px; resize: vertical; }
         input[type="submit"] { background-color: #007bff; color: white; padding: 12px 25px; border: none; border-radius: 5px; cursor: pointer; font-size: 16px; transition: background-color 0.2s; }
         input[type="submit"]:hover { background-color: #0056b3; }
         .response-container { display: flex; flex-wrap: wrap; gap: 20px; margin-top: 20px;}
-        .response-area { flex: 1; min-width: 300px; padding: 15px; background-color: #f9f9f9; border-radius: 5px; white-space: pre-wrap; /* Preserve line breaks */ border: 1px solid #e7e7e7;}
+        .response-area { flex: 1; min-width: 300px; /* Ensures responsiveness */ padding: 15px; background-color: #f9f9f9; border-radius: 5px; white-space: pre-wrap; border: 1px solid #e7e7e7;}
         .response-area h3 { margin-top: 0; color: #555; font-size: 18px; }
         .error-message { background-color: #ffebee; color: #c62828; border: 1px solid #ef9a9a; padding: 12px; border-radius: 5px; margin-bottom: 20px; text-align: center; white-space: pre-wrap;}
         .config-status { background-color: #e7f3fe; color: #0d47a1; border: 1px solid #b3e5fc; padding: 10px; border-radius: 5px; margin-bottom: 15px; font-size: 0.9em;}
@@ -42,8 +42,15 @@
                     <span class="config-nok">NOT CONFIGURED</span> (Edit <code>openai_client.py</code> or set <code>OPENAI_API_KEY</code> env var)
                 {% endif %}
             </p>
-            {% if not gemini_configured or not openai_configured %}
-            <p class="config-nok">Responses may be incomplete if API keys are not set.</p>
+            <p>Claude ({{ claude_model }}): 
+                {% if claude_configured %}
+                    <span class="config-ok">Configured</span>
+                {% else %}
+                    <span class="config-nok">NOT CONFIGURED</span> (Edit <code>claude_client.py</code> or set <code>ANTHROPIC_API_KEY</code> env var)
+                {% endif %}
+            </p>
+            {% if not gemini_configured or not openai_configured or not claude_configured %}
+            <p class="config-nok">Responses may be incomplete or missing if all API keys are not set.</p>
             {% endif %}
         </div>
 
@@ -71,6 +78,13 @@
             <div class="response-area">
                 <h3>OpenAI's Response ({{ openai_model }}):</h3>
                 <p>{{ openai_response }}</p>
+            </div>
+            {% endif %}
+            
+            {% if claude_response %}
+            <div class="response-area">
+                <h3>Claude's Response ({{ claude_model }}):</h3>
+                <p>{{ claude_response }}</p>
             </div>
             {% endif %}
         </div>


### PR DESCRIPTION
This version allows you to send a single prompt to Google Gemini, OpenAI (ChatGPT), and Anthropic Claude, and view their responses side-by-side on a web interface.

Key additions for Claude integration:
- Added `claude_client.py` to handle Anthropic Claude API interactions, including API key management (environment variable or direct edit) and error handling for Claude-specific API responses.
- Modified `app.py` to:
    - Import and use `claude_client.py`.
    - Check for Claude API key configuration.
    - Call the Claude API along with Gemini and OpenAI APIs.
    - Collect and relay Claude's response or errors to the template.
- Updated `templates/index.html` to:
    - Display API configuration status for Claude.
    - Render Claude's response in a dedicated section alongside Gemini and OpenAI.
- Added `anthropic` to `requirements.txt`.
- Updated `README.md` with comprehensive instructions for obtaining and configuring the Anthropic Claude API key, and to reflect the application's three-AI capabilities.