### PR TITLE
Fix blank historical responses on initial load and improve display lo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This application, "Uday's AI Agents," provides a simple, dark-themed web interfa
 
 The application includes a persistent Q&A history feature that allows you to review and reload past interactions.
 
-*   **Accessing History:** A "📜 History" button is located in the top header area (next to the API status gear icon). Clicking this button toggles a sidebar on the left side of the screen.
+*   **Accessing History:** A "📜 History" button is located in the top header area (next to the API status gear icon). Clicking this button toggles a sidebar on the left side of the screen. The sidebar will remember its last open or closed state across browser sessions and page reloads (e.g., after submitting a new query). If you leave it open, it will remain open.
 *   **Sidebar Content:** The history sidebar lists your past Q&A sessions. Each item typically shows:
     *   A snippet of your original prompt.
     *   The date and time of the interaction.

--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ import os
 
 # Import from our AI client modules
 from gemini_client import get_gemini_response, list_gemini_models, API_KEY as GEMINI_API_KEY
-DEFAULT_GEMINI_MODEL = 'models/gemini-1.5-flash-latest'
+DEFAULT_GEMINI_MODEL = 'models/gemini-1.5-flash-latest' 
 
 from openai_client import get_openai_response, list_openai_models, OPENAI_API_KEY_DIRECT, MODEL_NAME as DEFAULT_OPENAI_MODEL
 from claude_client import get_claude_response, list_claude_models, ANTHROPIC_API_KEY_DIRECT, MODEL_NAME as DEFAULT_CLAUDE_MODEL
@@ -24,13 +24,13 @@ def index():
     gemini_configured = check_gemini_config()
     openai_configured = check_openai_config()
     claude_configured = check_claude_config()
-
+    
     # --- Gemini Model Selection Logic ---
-    determined_gemini_model_id = DEFAULT_GEMINI_MODEL
+    determined_gemini_model_id = DEFAULT_GEMINI_MODEL 
     actual_gemini_models_for_dropdown = [{'id': DEFAULT_GEMINI_MODEL, 'display_name': f"Default: {DEFAULT_GEMINI_MODEL.split('/')[-1]}"}]
     current_gemini_list_error = None
     if gemini_configured:
-        gemini_models_list_from_api = list_gemini_models()
+        gemini_models_list_from_api = list_gemini_models() 
         if gemini_models_list_from_api and isinstance(gemini_models_list_from_api, list) and \
            gemini_models_list_from_api[0]['id'] not in ['ERROR', 'NO_MODELS', 'API_KEY_NOT_CONFIGURED']:
             actual_gemini_models_for_dropdown = gemini_models_list_from_api
@@ -73,7 +73,7 @@ def index():
 
     # --- Claude Model Selection Logic (Static List) ---
     determined_claude_model_id = DEFAULT_CLAUDE_MODEL
-    actual_claude_models_for_dropdown = list_claude_models()
+    actual_claude_models_for_dropdown = list_claude_models() 
     current_claude_list_error = None
     if not claude_configured:
         current_claude_list_error = "Claude API Key not configured."
@@ -84,7 +84,7 @@ def index():
         determined_claude_model_id = actual_claude_models_for_dropdown[0]['id']
     # else: determined_claude_model_id remains the hardcoded DEFAULT_CLAUDE_MODEL if list is empty or default not in it.
 
-    return render_template('index.html',
+    return render_template('index.html', 
                            gemini_configured=gemini_configured, openai_configured=openai_configured, claude_configured=claude_configured,
                            gemini_models=actual_gemini_models_for_dropdown, current_gemini_model=determined_gemini_model_id, gemini_list_error=current_gemini_list_error, gemini_model_display=determined_gemini_model_id,
                            openai_models=actual_openai_models_for_dropdown, current_openai_model=determined_openai_model_id, openai_list_error=current_openai_list_error, openai_model_display=determined_openai_model_id,
@@ -145,7 +145,7 @@ def get_response_route():
 
     # --- Claude Model Logic for POST re-render context ---
     _initial_claude_model_id = DEFAULT_CLAUDE_MODEL
-    _actual_claude_models_for_dropdown = list_claude_models()
+    _actual_claude_models_for_dropdown = list_claude_models() 
     _current_claude_list_error = None
     if not claude_configured: _current_claude_list_error = "Claude API Key not configured."
     is_default_claude_in_list = any(m['id'] == DEFAULT_CLAUDE_MODEL for m in _actual_claude_models_for_dropdown)
@@ -155,7 +155,7 @@ def get_response_route():
 
 
     if not prompt:
-        return render_template('index.html',
+        return render_template('index.html', 
                                error="Prompt cannot be empty.", prompt_text=prompt,
                                gemini_configured=gemini_configured, openai_configured=openai_configured, claude_configured=claude_configured,
                                gemini_models=_actual_gemini_models_for_dropdown, current_gemini_model=selected_gemini_model, gemini_list_error=_current_gemini_list_error, gemini_model_display=selected_gemini_model,
@@ -169,7 +169,7 @@ def get_response_route():
         gemini_response_text = get_gemini_response(prompt, model_to_use=selected_gemini_model)
         if "Error:" in gemini_response_text or "An error occurred:" in gemini_response_text: error_messages.append(f"Gemini ({selected_gemini_model.split('/')[-1]}): {gemini_response_text}")
     else: error_messages.append("Gemini: API key not configured.")
-
+    
     if openai_configured:
         openai_response_text = get_openai_response(prompt, model_to_use=selected_openai_model)
         if "Error:" in openai_response_text or "An unexpected error occurred with OpenAI:" in openai_response_text or "OpenAI AuthenticationError:" in openai_response_text or "OpenAI RateLimitError:" in openai_response_text or "OpenAI APIConnectionError:" in openai_response_text or "OpenAI NotFoundError:" in openai_response_text :
@@ -177,18 +177,18 @@ def get_response_route():
     else: error_messages.append("OpenAI: API key not configured.")
 
     if claude_configured:
-        claude_response_text = get_claude_response(prompt, model_to_use=selected_claude_model)
+        claude_response_text = get_claude_response(prompt, model_to_use=selected_claude_model) 
         if "Error:" in claude_response_text or "An unexpected error occurred with Anthropic:" in claude_response_text or "Anthropic AuthenticationError:" in claude_response_text or "Anthropic RateLimitError:" in claude_response_text or "Anthropic APIConnectionError:" in claude_response_text:
             error_messages.append(f"Claude ({selected_claude_model.replace('claude-3-haiku-','c3-haiku-')}): {claude_response_text}")
     else: error_messages.append("Claude: API key not configured.")
 
     final_error_message = " | ".join(error_messages) if error_messages else None
-
+    
     new_qna_set_to_save = True # Set this if we actually processed a prompt
     # If prompt was empty, we wouldn't reach here due to earlier return.
     # This flag is primarily to distinguish full response renders from initial page loads.
-
-    return render_template('index.html',
+        
+    return render_template('index.html', 
                            gemini_response=gemini_response_text, openai_response=openai_response_text, claude_response=claude_response_text,
                            prompt_text=prompt, error=final_error_message,
                            gemini_configured=gemini_configured, openai_configured=openai_configured, claude_configured=claude_configured,

--- a/claude_client.py
+++ b/claude_client.py
@@ -22,14 +22,14 @@ def list_claude_models(api_key: str = None) -> list:
     static_models = [
         {'id': 'claude-3-haiku-20240307', 'display_name': 'Claude 3 Haiku'},
         {'id': 'claude-3-sonnet-20240229', 'display_name': 'Claude 3 Sonnet'},
-        {'id': 'claude-instant-1.2', 'display_name': 'Claude Instant 1.2'}
+        {'id': 'claude-instant-1.2', 'display_name': 'Claude Instant 1.2'} 
         # Add claude-3-opus-20240229 if desired, but it's more expensive
     ]
     # To mimic the structure of dynamic listers in case of API key issues (though not applicable here for static)
     # This structure helps app.py handle it consistently if it expects an error dict.
     # For a static list, we assume API key configuration is not directly tied to listing.
     # However, if ANTHROPIC_API_KEY_DIRECT is not set, perhaps return an error indicator.
-
+    
     # For simplicity with a static list, we'll just return the list directly.
     # If app.py needs to check configuration before showing even static models,
     # that logic would reside in app.py based on check_claude_config().
@@ -61,7 +61,7 @@ def get_claude_response(prompt: str, model_to_use: str, api_key: str = None) -> 
             current_api_key = os.getenv('ANTHROPIC_API_KEY')
         elif ANTHROPIC_API_KEY_DIRECT != 'YOUR_ANTHROPIC_API_KEY':
             current_api_key = ANTHROPIC_API_KEY_DIRECT
-
+        
         if not current_api_key:
              return "Error: Anthropic API key not configured. Please set the ANTHROPIC_API_KEY environment variable or update ANTHROPIC_API_KEY_DIRECT in claude_client.py."
 
@@ -75,7 +75,7 @@ def get_claude_response(prompt: str, model_to_use: str, api_key: str = None) -> 
                 {"role": "user", "content": prompt}
             ]
         )
-
+        
         # The response structure for Claude API provides content as a list of blocks.
         # We need to extract the text from the first text block if available.
         if response.content and isinstance(response.content, list) and len(response.content) > 0:
@@ -124,12 +124,12 @@ if __name__ == '__main__':
 
         print(f"\n--- Testing Response Generation (Claude) ---")
         # Use the global MODEL_NAME (e.g., claude-3-haiku-20240307) as the default for this direct script test
-        print(f"Using model (for get_claude_response test): {MODEL_NAME}")
+        print(f"Using model (for get_claude_response test): {MODEL_NAME}") 
         test_prompt = "Explain the concept of 'emergence' in complex systems in a few sentences."
         print(f"Sending prompt: \"{test_prompt}\"")
-
-        api_response = get_claude_response(test_prompt, model_to_use=MODEL_NAME)
-
+        
+        api_response = get_claude_response(test_prompt, model_to_use=MODEL_NAME) 
+        
         print("\nResponse from Anthropic Claude:")
         print(api_response)
         print("--------------------------------------")

--- a/gemini_client.py
+++ b/gemini_client.py
@@ -48,7 +48,7 @@ def list_gemini_models(api_key: str = None) -> list:
     Args:
         api_key: Optional. Your Google AI Studio API key. If not provided,
                  it will try to use the API_KEY constant set in this file.
-
+    
     Returns:
         A list of dictionaries, where each dictionary has 'id' (model resource name)
         and 'display_name'. Returns an empty list if an error occurs or no suitable models are found.
@@ -62,7 +62,7 @@ def list_gemini_models(api_key: str = None) -> list:
 
     try:
         genai.configure(api_key=current_api_key)
-
+        
         # Iterate through all available models
         for model in genai.list_models():
             # Check if the model supports the 'generateContent' method (or similar)
@@ -71,9 +71,9 @@ def list_gemini_models(api_key: str = None) -> list:
             if any(method in ['generateContent', 'generate_content', 'models.generateContent'] for method in model.supported_generation_methods):
                 models_list.append({
                     'id': model.name,  # e.g., 'models/gemini-pro'
-                    'display_name': model.display_name
+                    'display_name': model.display_name 
                 })
-
+        
         if not models_list:
              # This case could happen if the API returns models but none support generateContent,
              # or if the API returns no models at all.
@@ -98,18 +98,18 @@ if __name__ == "__main__":
     else:
         print(f"Using model (for get_gemini_response test): {MODEL_NAME}")
         print("\nThis script will now send a test prompt to the Gemini API.")
-
+        
         test_prompt = "Explain what a Large Language Model is in one sentence."
         print(f"\nSending prompt: \"{test_prompt}\"")
-
+        
         # Get the response
         api_response = get_gemini_response(test_prompt, model_to_use=MODEL_NAME)
-
+        
         print("\nResponse from Gemini:")
         print(api_response)
 
         print("\n--- Get Response Test Complete ---")
-
+    
     print("\n--- Testing Model Listing ---")
     if API_KEY == 'YOUR_API_KEY':
         print("Skipping model listing test as API_KEY is not configured.")

--- a/openai_client.py
+++ b/openai_client.py
@@ -19,7 +19,7 @@ def list_openai_models(api_key: str = None) -> list:
 
     Args:
         api_key: Optional. Your OpenAI API key.
-
+    
     Returns:
         A list of dictionaries, where each has 'id' and 'display_name' (which is also the id).
         Returns a list with an error indicator if an error occurs.
@@ -47,7 +47,7 @@ def list_openai_models(api_key: str = None) -> list:
                 # 'instruct' can sometimes be chat-like, but often refers to older completion models.
                 # We'll keep 'instruct' in the blacklist for now to prefer pure chat models like gpt-3.5-turbo, gpt-4.
                 # If too few models appear, 'instruct' could be removed from this blacklist.
-                non_chat_terms = ['vision', 'image', 'audio', 'embed', 'instruct', 'davinci', 'babbage', 'curie', 'ada']
+                non_chat_terms = ['vision', 'image', 'audio', 'embed', 'instruct', 'davinci', 'babbage', 'curie', 'ada'] 
 
                 is_not_specialized_non_chat = not any(term in model_id_lower for term in non_chat_terms)
 
@@ -58,10 +58,10 @@ def list_openai_models(api_key: str = None) -> list:
 
                 if is_likely_chat_model and is_not_specialized_non_chat:
                     processed_models.append({'id': model.id, 'display_name': model.id})
-
+        
         if not processed_models:
             return [{'id': 'NO_MODELS', 'display_name': 'No suitable GPT models found'}]
-
+            
         # Sort models, perhaps to put gpt-4 versions before gpt-3.5 if desired, or just alphabetically
         processed_models.sort(key=lambda x: x['id'], reverse=True) # Simple sort, gpt-4 often appears before gpt-3.5
 
@@ -87,7 +87,7 @@ def get_openai_response(prompt: str, model_to_use: str, api_key: str = None) -> 
     client = None
     if not model_to_use:
         return "Error: No model specified for OpenAI."
-
+        
     try:
         if api_key:
             client = openai.OpenAI(api_key=api_key)
@@ -149,13 +149,13 @@ if __name__ == '__main__':
 
         print(f"\n--- Testing Response Generation (OpenAI) ---")
         # Use the global MODEL_NAME as the default for this direct script test
-        print(f"Using model (for get_openai_response test): {MODEL_NAME}")
+        print(f"Using model (for get_openai_response test): {MODEL_NAME}") 
         test_prompt = "What is the capital of France?"
         print(f"Sending prompt: \"{test_prompt}\"")
-
+        
         # Pass the model_to_use argument
-        api_response = get_openai_response(test_prompt, model_to_use=MODEL_NAME)
-
+        api_response = get_openai_response(test_prompt, model_to_use=MODEL_NAME) 
+        
         print("\nResponse from OpenAI (ChatGPT):")
         print(api_response)
         print("--------------------------------------")

--- a/static/script.js
+++ b/static/script.js
@@ -38,7 +38,7 @@ function showToast(message, type = 'error', duration = 5000) {
     container.appendChild(toast);
 
     // Trigger reflow for animation
-    toast.offsetHeight;
+    toast.offsetHeight; 
 
     // Add class to make it visible and animate
     toast.classList.add('show');
@@ -61,322 +61,9 @@ document.addEventListener('DOMContentLoaded', function() {
     const hiddenGeminiInput = document.getElementById('gemini_model_select_hidden');
 
     if (visualGeminiSelect && hiddenGeminiInput) {
-        // Initialize hidden field with the current value of the visual select
-        // (which should be correctly pre-selected by Jinja via current_gemini_model)
         hiddenGeminiInput.value = visualGeminiSelect.value;
-
-        // Add event listener for changes on the visual select
         visualGeminiSelect.addEventListener('change', function() {
             hiddenGeminiInput.value = this.value;
-        });
-    }
-});
-
-// --- History Sidebar UI Management ---
-document.addEventListener('DOMContentLoaded', function() {
-    const historySidebar = document.getElementById('historySidebar');
-    const openHistorySidebarButton = document.getElementById('openHistorySidebar');
-    const closeHistorySidebarButton = document.getElementById('closeHistorySidebar');
-    const historyListUl = document.getElementById('historyList');
-    const clearHistoryButton = document.getElementById('clearHistoryButton');
-
-    // --- Elements for displaying loaded history ---
-    const mainPromptTextarea = document.getElementById('prompt');
-    // Assuming response <p> tags are identifiable. If not, we need specific IDs or classes.
-    // Let's assume the <p> tags holding responses are the direct <p> children of their respective .response-area,
-    // and are NOT the .error-text or .placeholder-text paragraphs.
-    // This might need refinement if HTML structure for responses is more complex.
-    // const geminiResponseP = document.querySelector('#geminiResponseAreaContainer .response-area > p:not(.error-text):not(.placeholder-text)'); // Needs IDs on response areas
-    // const openaiResponseP = document.querySelector('#openaiResponseAreaContainer .response-area > p:not(.error-text):not(.placeholder-text)');
-    // const claudeResponseP = document.querySelector('#claudeResponseAreaContainer .response-area > p:not(.error-text):not(.placeholder-text)');
-
-    // Placeholders and error <p> tags (to hide/show them)
-    // const geminiPlaceholderP = document.querySelector('#geminiResponseAreaContainer .response-area > p.placeholder-text');
-    // const geminiErrorP = document.querySelector('#geminiResponseAreaContainer .response-area > p.error-text');
-    // ... similar for openai and claude ...
-
-    // Model selectors (visual and hidden)
-    const visualGeminiSelect = document.getElementById('gemini_model_select_visual');
-    const hiddenGeminiInput = document.getElementById('gemini_model_select_hidden');
-    const visualOpenAISelect = document.getElementById('openai_model_select_visual');
-    const hiddenOpenAIInput = document.getElementById('openai_model_select_hidden');
-    const visualClaudeSelect = document.getElementById('claude_model_select_visual');
-    const hiddenClaudeInput = document.getElementById('claude_model_select_hidden');
-
-    // These constants would need to be passed from app.py if used as JS fallbacks here.
-    // For now, relying on qnaSet.xxx_model being present or visualSelect.value.
-    // const DEFAULT_GEMINI_MODEL = "{{ DEFAULT_GEMINI_MODEL }}"; // Example, would need proper injection
-    // const DEFAULT_OPENAI_MODEL = "{{ DEFAULT_OPENAI_MODEL }}";
-    // const DEFAULT_CLAUDE_MODEL = "{{ DEFAULT_CLAUDE_MODEL }}";
-
-
-    let currentHistory = []; // In-memory copy of history for easier access
-
-    function renderHistorySidebar() {
-        if (!historyListUl) return;
-        historyListUl.innerHTML = ''; // Clear existing items
-        currentHistory = loadHistory(); // Load from Local Storage
-
-        if (currentHistory.length === 0) {
-            const li = document.createElement('li');
-            li.textContent = 'No history yet.';
-            li.style.fontStyle = 'italic';
-            li.style.color = '#777777';
-            historyListUl.appendChild(li);
-            return;
-        }
-
-        currentHistory.forEach((qnaSet, index) => {
-            const li = document.createElement('li');
-            li.dataset.historyIndex = index; // Store index to retrieve full data
-
-            const promptSnippet = document.createElement('span');
-            promptSnippet.className = 'history-prompt-snippet';
-            promptSnippet.textContent = qnaSet.prompt.substring(0, 30) + (qnaSet.prompt.length > 30 ? '...' : '');
-
-            const timestamp = document.createElement('span');
-            timestamp.className = 'history-timestamp';
-            timestamp.textContent = new Date(qnaSet.timestamp).toLocaleString();
-
-            li.appendChild(promptSnippet);
-            li.appendChild(timestamp);
-
-            li.addEventListener('click', function() {
-                loadQASetIntoUI(parseInt(this.dataset.historyIndex));
-                // Optionally close sidebar:
-                // if (historySidebar) historySidebar.classList.remove('open');
-
-                // Highlight active item
-                document.querySelectorAll('#historyList li').forEach(item => item.classList.remove('active-history-item'));
-                this.classList.add('active-history-item');
-            });
-            historyListUl.appendChild(li);
-        });
-    }
-
-    function displayResponseInArea(responseAreaId, responseText) {
-        const responseArea = document.getElementById(responseAreaId);
-        if (!responseArea) { console.warn("Response area not found:", responseAreaId); return; }
-
-        const pResponse = responseArea.querySelector('p:not(.placeholder-text):not(.error-text)');
-        const pPlaceholder = responseArea.querySelector('p.placeholder-text');
-        const pError = responseArea.querySelector('p.error-text');
-
-        // Clear previous state
-        if (pResponse) { pResponse.textContent = ''; pResponse.classList.remove('error-text'); } // Ensure error-text is removed if it was added
-        if (pPlaceholder) pPlaceholder.style.display = 'none';
-        if (pError) { pError.textContent = ''; pError.style.display = 'none'; }
-
-        const isErrorResponse = typeof responseText === 'string' && (responseText.startsWith("Error:") || responseText.includes("An error occurred") || responseText.includes("API key not configured") || responseText.includes("Auth Error"));
-
-        if (isErrorResponse) {
-            if (pError) {
-                pError.textContent = responseText;
-                pError.style.display = 'block';
-            } else if (pResponse) { // Fallback if dedicated error <p> not found
-                pResponse.textContent = responseText;
-                pResponse.classList.add('error-text');
-            }
-        } else if (responseText && typeof responseText === 'string') {
-            if (pResponse) {
-                pResponse.textContent = responseText;
-            } else { console.warn("Main response <p> tag not found in", responseAreaId); }
-        } else { // No response and not an error (e.g. AI was not called or responseText is null/undefined)
-            if (pPlaceholder) {
-                pPlaceholder.style.display = 'block';
-            } else { console.warn("Placeholder <p> tag not found in", responseAreaId); }
-        }
-    }
-
-
-    function loadQASetIntoUI(index) {
-        if (index < 0 || index >= currentHistory.length) return;
-        const qnaSet = currentHistory[index];
-
-        if (mainPromptTextarea) mainPromptTextarea.value = qnaSet.prompt;
-
-        displayResponseInArea('geminiResponseArea', qnaSet.gemini_response);
-        displayResponseInArea('openaiResponseArea', qnaSet.openai_response);
-        displayResponseInArea('claudeResponseArea', qnaSet.claude_response);
-
-        // Update model selectors
-        if (visualGeminiSelect && hiddenGeminiInput) {
-            visualGeminiSelect.value = qnaSet.gemini_model || visualGeminiSelect.options[0].value; // Fallback to first option
-            hiddenGeminiInput.value = visualGeminiSelect.value;
-        }
-        if (visualOpenAISelect && hiddenOpenAIInput) {
-            visualOpenAISelect.value = qnaSet.openai_model || visualOpenAISelect.options[0].value;
-            hiddenOpenAIInput.value = visualOpenAISelect.value;
-        }
-        if (visualClaudeSelect && hiddenClaudeInput) {
-            visualClaudeSelect.value = qnaSet.claude_model || visualClaudeSelect.options[0].value;
-            hiddenClaudeInput.value = visualClaudeSelect.value;
-        }
-
-        updateResponseHeaderModelName('geminiResponseArea', qnaSet.gemini_model, visualGeminiSelect);
-        updateResponseHeaderModelName('openaiResponseArea', qnaSet.openai_model, visualOpenAISelect);
-        updateResponseHeaderModelName('claudeResponseArea', qnaSet.claude_model, visualClaudeSelect);
-    }
-
-    function updateResponseHeaderModelName(responseAreaId, modelId, visualSelectElement) {
-        const responseArea = document.getElementById(responseAreaId);
-        if (!responseArea) return;
-        const h3 = responseArea.querySelector('.response-header > h3');
-        if (!h3) return;
-
-        const aiLabelSpan = h3.querySelector('.ai-label');
-        let displayModelId = "";
-
-        if (modelId) {
-            displayModelId = modelId.split('/').pop(); // e.g., gemini-1.5-flash-latest
-            if (responseAreaId === 'claudeResponseArea') {
-                displayModelId = displayModelId.replace('claude-3-haiku-', 'c3-haiku-');
-            }
-        } else if (visualSelectElement && visualSelectElement.options.length > 0) {
-            // Fallback to current selected display text in the dropdown if modelId is missing in history
-            // This is a bit more complex as option text includes display name and ID.
-            // Simplification: just show nothing or a generic placeholder if modelId is truly missing.
-            // For now, let's assume modelId will usually be there.
-            // If not, the H3 will just show " ( )" if modelId is null/undefined.
-        }
-
-
-        if (aiLabelSpan && aiLabelSpan.nextSibling && aiLabelSpan.nextSibling.nodeType === Node.TEXT_NODE) {
-            aiLabelSpan.nextSibling.textContent = ` (${displayModelId})`;
-        } else if (aiLabelSpan) { // If no text node, create one (less likely with current HTML)
-             const textNode = document.createTextNode(` (${displayModelId})`);
-             h3.appendChild(textNode);
-        }
-    }
-
-
-    // Sidebar Toggle Logic
-    if (openHistorySidebarButton && historySidebar) {
-        openHistorySidebarButton.onclick = function() {
-            historySidebar.classList.add('open');
-            renderHistorySidebar(); // Re-render history every time it's opened, in case of external changes
-        }
-    }
-    if (closeHistorySidebarButton && historySidebar) {
-        closeHistorySidebarButton.onclick = function() {
-            historySidebar.classList.remove('open');
-        }
-    }
-
-    // Clear History Button Logic
-    if (clearHistoryButton) {
-        clearHistoryButton.onclick = function() {
-            if (confirm("Are you sure you want to clear all Q&A history? This cannot be undone.")) {
-                clearHistory(); // Clears Local Storage
-                renderHistorySidebar(); // Re-renders the (now empty) sidebar
-                showToast("History cleared.", "success");
-            }
-        }
-    }
-
-    // Initial population of history sidebar (if it's not initially open, this could be deferred)
-    // renderHistorySidebar(); // Call it if sidebar might be open on load, or on first open.
-    // For now, let's populate it when the sidebar is opened.
-});
-
-// --- Q&A History Management ---
-const UDAYS_AI_AGENTS_HISTORY_KEY = 'udaysAiAgentsHistory';
-const MAX_HISTORY_ITEMS = 50; // Optional: Limit the number of history items
-
-/**
- * Loads the Q&A history from Local Storage.
- * @returns {Array} An array of Q&A set objects, or an empty array if none exists or an error occurs.
- */
-function loadHistory() {
-    try {
-        const historyJson = localStorage.getItem(UDAYS_AI_AGENTS_HISTORY_KEY);
-        if (historyJson) {
-            const history = JSON.parse(historyJson);
-            // Basic validation if it's an array
-            return Array.isArray(history) ? history : [];
-        }
-        return [];
-    } catch (error) {
-        console.error("Error loading history from Local Storage:", error);
-        return []; // Return empty array on error
-    }
-}
-
-/**
- * Saves a new Q&A set to the history in Local Storage.
- * @param {object} qnaSet - The Q&A set object to save.
- *                          Expected structure: { prompt: string, gemini_response: string, gemini_model: string,
- *                                                openai_response: string, openai_model: string,
- *                                                claude_response: string, claude_model: string,
- *                                                timestamp: string }
- */
-function saveQASet(qnaSet) {
-    if (!qnaSet || typeof qnaSet.prompt === 'undefined') {
-        console.error("Invalid Q&A set provided to saveQASet:", qnaSet);
-        return;
-    }
-    try {
-        let history = loadHistory();
-
-        // Add the new set to the beginning of the history (most recent first)
-        history.unshift(qnaSet);
-
-        // Optional: Limit history size
-        if (history.length > MAX_HISTORY_ITEMS) {
-            history = history.slice(0, MAX_HISTORY_ITEMS); // Keep only the newest MAX_HISTORY_ITEMS
-        }
-
-        localStorage.setItem(UDAYS_AI_AGENTS_HISTORY_KEY, JSON.stringify(history));
-    } catch (error) {
-        console.error("Error saving history to Local Storage:", error);
-        // Potentially show a toast error to the user if storage is full
-        if (error.name === 'QuotaExceededError') {
-            showToast('History storage limit reached. Oldest items may not be saved.', 'error');
-        }
-    }
-}
-
-/**
- * Clears all Q&A history from Local Storage.
- */
-function clearHistory() {
-    try {
-        localStorage.removeItem(UDAYS_AI_AGENTS_HISTORY_KEY);
-        console.log("Q&A history cleared from Local Storage.");
-        // Later, this will also need to update the UI (e.g., clear the sidebar)
-    } catch (error) {
-        console.error("Error clearing history from Local Storage:", error);
-    }
-}
-
-// Example of how qnaSet might be structured (for documentation/testing purposes):
-/*
-const exampleQnaSet = {
-    id: new Date().getTime(), // Or a UUID, for unique identification if needed for UI keys
-    prompt: "What is the weather like?",
-    gemini_response: "Gemini says it's sunny.",
-    gemini_model: "models/gemini-1.5-flash-latest",
-    openai_response: "OpenAI says it's partly cloudy.",
-    openai_model: "gpt-3.5-turbo",
-    claude_response: "Claude says rain is expected.",
-    claude_model: "claude-3-haiku-20240307",
-    timestamp: new Date().toISOString()
-};
-*/
-
-// --- Claude Model Selector Sync ---
-document.addEventListener('DOMContentLoaded', function() {
-    const visualClaudeSelect = document.getElementById('claude_model_select_visual');
-    const hiddenClaudeInput = document.getElementById('claude_model_select_hidden');
-
-    if (visualClaudeSelect && hiddenClaudeInput) {
-        // Initialize hidden field with the current value of the visual select
-        // (which should be correctly pre-selected by Jinja via current_claude_model)
-        hiddenClaudeInput.value = visualClaudeSelect.value;
-
-        // Add event listener for changes on the visual select
-        visualClaudeSelect.addEventListener('change', function() {
-            hiddenClaudeInput.value = this.value;
         });
     }
 });
@@ -387,13 +74,305 @@ document.addEventListener('DOMContentLoaded', function() {
     const hiddenOpenAIInput = document.getElementById('openai_model_select_hidden');
 
     if (visualOpenAISelect && hiddenOpenAIInput) {
-        // Initialize hidden field with the current value of the visual select
-        // (which should be correctly pre-selected by Jinja via current_openai_model)
         hiddenOpenAIInput.value = visualOpenAISelect.value;
-
-        // Add event listener for changes on the visual select
         visualOpenAISelect.addEventListener('change', function() {
             hiddenOpenAIInput.value = this.value;
         });
     }
 });
+
+// --- Claude Model Selector Sync ---
+document.addEventListener('DOMContentLoaded', function() {
+    const visualClaudeSelect = document.getElementById('claude_model_select_visual');
+    const hiddenClaudeInput = document.getElementById('claude_model_select_hidden');
+
+    if (visualClaudeSelect && hiddenClaudeInput) {
+        hiddenClaudeInput.value = visualClaudeSelect.value;
+        visualClaudeSelect.addEventListener('change', function() {
+            hiddenClaudeInput.value = this.value;
+        });
+    }
+});
+
+
+// --- History Sidebar UI Management ---
+const SIDEBAR_STATE_KEY = 'udaysAiAgentsSidebarState';
+
+document.addEventListener('DOMContentLoaded', function() {
+    let currentHistory = []; // Correctly scoped for functions within this DOMContentLoaded
+
+    const historySidebar = document.getElementById('historySidebar');
+    const openHistorySidebarButton = document.getElementById('openHistorySidebar');
+    const closeHistorySidebarButton = document.getElementById('closeHistorySidebar');
+    const historyListUl = document.getElementById('historyList');
+    const clearHistoryButton = document.getElementById('clearHistoryButton');
+
+    // Load and Apply Initial Sidebar State
+    if (historySidebar) {
+        const savedSidebarState = localStorage.getItem(SIDEBAR_STATE_KEY);
+        console.log('Loaded sidebar state:', savedSidebarState);
+        if (savedSidebarState === 'open') {
+            console.log('Applying open state from Local Storage.');
+            historySidebar.classList.add('open');
+            if (typeof renderHistorySidebar === 'function') {
+                console.log('Calling renderHistorySidebar from DOMContentLoaded due to saved open state.');
+                renderHistorySidebar(); 
+            }
+        } else {
+            console.log('Applying closed state or default.');
+            historySidebar.classList.remove('open'); 
+        }
+    }
+
+    const mainPromptTextarea = document.getElementById('prompt');
+    const visualGeminiSelect = document.getElementById('gemini_model_select_visual');
+    const hiddenGeminiInput = document.getElementById('gemini_model_select_hidden');
+    const visualOpenAISelect = document.getElementById('openai_model_select_visual');
+    const hiddenOpenAIInput = document.getElementById('openai_model_select_hidden');
+    const visualClaudeSelect = document.getElementById('claude_model_select_visual');
+    const hiddenClaudeInput = document.getElementById('claude_model_select_hidden');
+
+    function renderHistorySidebar() {
+        console.log('renderHistorySidebar called.');
+        if (!historyListUl) return;
+        historyListUl.innerHTML = '';
+        currentHistory = loadHistory(); // Assigns to the scoped currentHistory
+        console.log('History data for rendering:', currentHistory);
+
+        if (currentHistory.length === 0) {
+            console.log('Rendering sidebar with "No history yet."');
+            const li = document.createElement('li');
+            li.textContent = 'No history yet.';
+            li.style.fontStyle = 'italic';
+            li.style.color = '#777777';
+            historyListUl.appendChild(li);
+            return;
+        }
+
+        currentHistory.forEach((qnaSet, index) => {
+            const li = document.createElement('li');
+            li.dataset.historyIndex = index;
+            console.log('Rendering history item:', qnaSet);
+
+            const promptSnippet = document.createElement('span');
+            promptSnippet.className = 'history-prompt-snippet';
+            promptSnippet.textContent = qnaSet.prompt.substring(0, 30) + (qnaSet.prompt.length > 30 ? '...' : '');
+            
+            const timestamp = document.createElement('span');
+            timestamp.className = 'history-timestamp';
+            timestamp.textContent = new Date(qnaSet.timestamp).toLocaleString();
+
+            li.appendChild(promptSnippet);
+            li.appendChild(timestamp);
+
+            li.addEventListener('click', function() {
+                loadQASetIntoUI(parseInt(this.dataset.historyIndex));
+                document.querySelectorAll('#historyList li').forEach(item => item.classList.remove('active-history-item'));
+                this.classList.add('active-history-item');
+            });
+            historyListUl.appendChild(li);
+        });
+    }
+
+function displayResponseInArea(responseAreaId, responseText) {
+    const responseArea = document.getElementById(responseAreaId);
+    if (!responseArea) {
+        console.error(`Response area with ID '${responseAreaId}' not found.`);
+        return;
+    }
+
+    const pResponseContent = responseArea.querySelector('.ai-response-content');
+    const pErrorText = responseArea.querySelector('.ai-response-error-text'); // Specific class for AI errors
+    const pPlaceholder = responseArea.querySelector('.placeholder-text');
+
+    // Ensure all elements are found before proceeding
+    if (!pResponseContent || !pErrorText || !pPlaceholder) {
+        console.error(`One or more required p tags not found in '${responseAreaId}'. Structure: .ai-response-content, .ai-response-error-text, .placeholder-text`);
+        return;
+    }
+
+    // Hide all paragraphs initially
+    pResponseContent.classList.add('hidden');
+    pErrorText.classList.add('hidden');
+    pPlaceholder.classList.add('hidden');
+
+    // Clear previous content to be safe
+    pResponseContent.textContent = '';
+    pErrorText.textContent = '';
+    // Placeholder text is static, so no need to clear/reset its content unless it changes dynamically
+
+    if (responseText && typeof responseText === 'string' && responseText.trim() !== "") {
+        // Heuristic to check if the responseText is an error message from our clients
+        // (These are the patterns used in the client .py files)
+        const isError = responseText.startsWith("Error:") || 
+                        responseText.includes("An error occurred") || 
+                        responseText.includes("API key not configured") || 
+                        responseText.includes("No model specified") ||
+                        responseText.includes("AuthenticationError") ||
+                        responseText.includes("RateLimitError") ||
+                        responseText.includes("APIConnectionError") ||
+                        responseText.includes("NotFoundError"); // Added from OpenAI client
+
+        if (isError) {
+            pErrorText.textContent = responseText;
+            pErrorText.classList.remove('hidden');
+        } else {
+            pResponseContent.textContent = responseText;
+            pResponseContent.classList.remove('hidden');
+        }
+    } else {
+        // If responseText is null, undefined, or empty string, show placeholder
+        pPlaceholder.textContent = `Response from ${responseAreaId.replace('ResponseArea','')} will appear here once a prompt is submitted.`; // Ensure placeholder text is fresh
+        pPlaceholder.classList.remove('hidden');
+    }
+}
+
+    function loadQASetIntoUI(index) {
+        console.log('loadQASetIntoUI called with index:', index); // DEBUG
+        if (index < 0 || index >= currentHistory.length) {
+            console.error('Invalid index for loadQASetIntoUI:', index); // DEBUG
+            return;
+        }
+        const qnaSet = currentHistory[index];
+        console.log('Loading Q&A set from history:', qnaSet); // DEBUG
+
+        if (mainPromptTextarea) mainPromptTextarea.value = qnaSet.prompt;
+        
+        displayResponseInArea('geminiResponseArea', qnaSet.gemini_response);
+        displayResponseInArea('openaiResponseArea', qnaSet.openai_response);
+        displayResponseInArea('claudeResponseArea', qnaSet.claude_response);
+
+        if (visualGeminiSelect && hiddenGeminiInput) {
+            visualGeminiSelect.value = qnaSet.gemini_model || visualGeminiSelect.options[0].value;
+            hiddenGeminiInput.value = visualGeminiSelect.value;
+        }
+        if (visualOpenAISelect && hiddenOpenAIInput) {
+            visualOpenAISelect.value = qnaSet.openai_model || visualOpenAISelect.options[0].value;
+            hiddenOpenAIInput.value = visualOpenAISelect.value;
+        }
+        if (visualClaudeSelect && hiddenClaudeInput) {
+            visualClaudeSelect.value = qnaSet.claude_model || visualClaudeSelect.options[0].value;
+            hiddenClaudeInput.value = visualClaudeSelect.value;
+        }
+        
+        updateResponseHeaderModelName('geminiResponseArea', qnaSet.gemini_model, visualGeminiSelect);
+        updateResponseHeaderModelName('openaiResponseArea', qnaSet.openai_model, visualOpenAISelect);
+        updateResponseHeaderModelName('claudeResponseArea', qnaSet.claude_model, visualClaudeSelect);
+    }
+    
+    function updateResponseHeaderModelName(responseAreaId, modelId, visualSelectElement) {
+        const responseArea = document.getElementById(responseAreaId);
+        if (!responseArea) return;
+        const h3 = responseArea.querySelector('.response-header > h3');
+        if (!h3) return;
+        
+        const aiLabelSpan = h3.querySelector('.ai-label');
+        let displayModelId = "";
+
+        if (modelId) {
+            displayModelId = modelId.split('/').pop();
+            if (responseAreaId === 'claudeResponseArea') { 
+                displayModelId = displayModelId.replace('claude-3-haiku-', 'c3-haiku-');
+            }
+        } // No complex fallback to visualSelectElement.options[0].text needed here for now
+        
+        if (aiLabelSpan && aiLabelSpan.nextSibling && aiLabelSpan.nextSibling.nodeType === Node.TEXT_NODE) {
+            aiLabelSpan.nextSibling.textContent = ` (${displayModelId})`;
+        } else if (aiLabelSpan && !aiLabelSpan.nextSibling) { // If text node doesn't exist, create it
+             const textNode = document.createTextNode(` (${displayModelId})`);
+             h3.appendChild(textNode);
+        }
+    }
+
+    // Sidebar Toggle Logic
+    if (openHistorySidebarButton && historySidebar) {
+        openHistorySidebarButton.onclick = function() {
+            console.log('Open sidebar button clicked.');
+            historySidebar.classList.add('open');
+            localStorage.setItem(SIDEBAR_STATE_KEY, 'open');
+            console.log('Saved sidebar state: open');
+            if (typeof renderHistorySidebar === 'function') { 
+                renderHistorySidebar();
+            }
+        }
+    }
+    if (closeHistorySidebarButton && historySidebar) {
+        closeHistorySidebarButton.onclick = function() {
+            console.log('Close sidebar button clicked.');
+            historySidebar.classList.remove('open');
+            localStorage.setItem(SIDEBAR_STATE_KEY, 'closed');
+            console.log('Saved sidebar state: closed');
+        }
+    }
+
+    // Clear History Button Logic
+    if (clearHistoryButton) {
+        clearHistoryButton.onclick = function() {
+            if (confirm("Are you sure you want to clear all Q&A history? This cannot be undone.")) {
+                clearHistory(); 
+                renderHistorySidebar(); 
+                showToast("History cleared.", "success");
+            }
+        }
+    }
+});
+
+// --- Q&A History Management --- (Core functions: loadHistory, saveQASet, clearHistory)
+const UDAYS_AI_AGENTS_HISTORY_KEY = 'udaysAiAgentsHistory';
+const MAX_HISTORY_ITEMS = 50; 
+
+function loadHistory() {
+    console.log('loadHistory called.'); 
+    let historyToReturn = [];
+    try {
+        const historyJson = localStorage.getItem(UDAYS_AI_AGENTS_HISTORY_KEY);
+        console.log('Loaded history JSON from Local Storage:', historyJson); 
+        if (historyJson) {
+            const parsedHistory = JSON.parse(historyJson);
+            console.log('Parsed history:', parsedHistory); 
+            if (Array.isArray(parsedHistory)) {
+                historyToReturn = parsedHistory;
+            }
+        } else {
+            console.log('No history found in Local Storage or historyJson is null/empty.'); 
+        }
+    } catch (error) {
+        console.error('Failed to parse history JSON:', error); 
+    }
+    console.log('loadHistory returning:', historyToReturn); 
+    return historyToReturn;
+}
+
+function saveQASet(qnaSet) {
+    console.log('saveQASet called with:', qnaSet); 
+    if (!qnaSet || typeof qnaSet.prompt === 'undefined') {
+        console.error("Invalid Q&A set provided to saveQASet:", qnaSet);
+        return;
+    }
+    try {
+        let history = loadHistory();
+        history.unshift(qnaSet); 
+        if (history.length > MAX_HISTORY_ITEMS) {
+            history = history.slice(0, MAX_HISTORY_ITEMS); 
+        }
+        console.log('Saving to Local Storage:', JSON.stringify(history)); 
+        localStorage.setItem(UDAYS_AI_AGENTS_HISTORY_KEY, JSON.stringify(history));
+    } catch (error) {
+        console.error('Error in saveQASet:', error); 
+        if (error.name === 'QuotaExceededError') {
+            showToast('History storage limit reached. Oldest items may not be saved.', 'error');
+        }
+    }
+}
+
+function clearHistory() {
+    try {
+        localStorage.removeItem(UDAYS_AI_AGENTS_HISTORY_KEY);
+        console.log("Q&A history cleared from Local Storage.");
+    } catch (error) {
+        console.error("Error clearing history from Local Storage:", error);
+    }
+}
+
+/* Example QnaSet Structure (already present) */
+// ...

--- a/static/style.css
+++ b/static/style.css
@@ -1,6 +1,6 @@
-body {
+body { 
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-    margin: 0;
+    margin: 0; 
     padding: 0; /* Remove body padding if header is full width */
     background-color: #121212; /* Dark background for the body */
     color: #e0e0e0; /* Light grey text for readability */
@@ -21,7 +21,7 @@ body {
 /* Keep existing .container styles for max-width, margin: auto, padding (for content) */
 /* We might need to adjust padding for the header's inner .container */
 #appHeader .container {
-    padding-top: 0;
+    padding-top: 0; 
     padding-bottom: 0;
     /* Remove box-shadow and border from here if #appHeader has them */
     box-shadow: none;
@@ -35,12 +35,12 @@ body {
     /* Keep existing box-shadow, border, background-color for this content area */
 }
 
-.container {
-    max-width: 1200px;
-    margin: auto;
+.container { 
+    max-width: 1200px; 
+    margin: auto; 
     background-color: #1e1e1e; /* Slightly lighter dark for the main container */
-    padding: 25px;
-    border-radius: 10px;
+    padding: 25px; 
+    border-radius: 10px; 
     box-shadow: 0 4px 20px rgba(0,0,0,0.3); /* Adjusted shadow for dark theme */
     border: 1px solid #333; /* Subtle border for the container */
 }
@@ -49,15 +49,15 @@ body {
     margin-bottom: 15px; /* Space below title */
     font-size: 1.8em; /* Slightly adjust size if needed */
     color: #ffffff; /* White or very light grey for main heading */
-    text-align: center;
+    text-align: center; 
     font-weight: 500;
 }
 
 
 h2 { /* General sub-headings, if any are used outside response areas */
-    color: #cccccc;
-    margin-top: 30px;
-    border-bottom: 1px solid #444;
+    color: #cccccc; 
+    margin-top: 30px; 
+    border-bottom: 1px solid #444; 
     padding-bottom: 8px;
     font-weight: 400;
 }
@@ -66,7 +66,7 @@ h2 { /* General sub-headings, if any are used outside response areas */
     display: flex;
     flex-direction: column; /* Label on top, then input-button-wrapper */
     gap: 8px; /* Reduced gap slightly */
-    margin-top: 10px;
+    margin-top: 10px; 
 }
 
 .input-button-wrapper {
@@ -86,14 +86,14 @@ h2 { /* General sub-headings, if any are used outside response areas */
 #promptForm textarea#prompt {
     flex-grow: 1; /* Textarea takes available space */
     /* width: 100%; Is implicitly handled by flex-grow, but ensure no fixed width conflicts */
-    box-sizing: border-box;
-    margin-bottom: 0;
+    box-sizing: border-box; 
+    margin-bottom: 0; 
     /* rows="3" in HTML controls initial height, CSS resize:vertical allows user adjustment */
-    padding: 12px;
-    border-radius: 6px;
-    border: 1px solid #444;
-    font-size: 16px;
-    resize: vertical;
+    padding: 12px; 
+    border-radius: 6px; 
+    border: 1px solid #444; 
+    font-size: 16px; 
+    resize: vertical; 
     background-color: #2c2c2c; /* Darker background for textarea */
     color: #e0e0e0; /* Light text in textarea */
     min-height: 80px; /* Original min-height, adjust if needed with rows="3" */
@@ -111,33 +111,33 @@ h2 { /* General sub-headings, if any are used outside response areas */
     white-space: nowrap; /* Prevent text wrapping on button */
     flex-shrink: 0; /* Prevent button from shrinking if space is tight */
     background-color: #007bff; /* Primary accent color (e.g., a professional blue) */
-    color: white;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 16px;
+    color: white; 
+    border: none; 
+    border-radius: 6px; 
+    cursor: pointer; 
+    font-size: 16px; 
     transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
     font-weight: 500;
 }
-#promptForm input[type="submit"]:hover {
+#promptForm input[type="submit"]:hover { 
     background-color: #0056b3; /* Darker shade on hover */
     box-shadow: 0 2px 8px rgba(0,123,255,0.3);
 }
 
-.response-container {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 25px;
+.response-container { 
+    display: flex; 
+    flex-wrap: wrap; 
+    gap: 25px; 
     margin-top: 25px;
 }
 
-.response-area {
-    flex: 1;
-    min-width: 300px;
-    padding: 15px 20px;
+.response-area { 
+    flex: 1; 
+    min-width: 300px; 
+    padding: 15px 20px; 
     background-color: #2c2c2c; /* Dark background for response areas */
-    border-radius: 8px;
-    white-space: pre-wrap;
+    border-radius: 8px; 
+    white-space: pre-wrap; 
     border: 1px solid #444; /* Subtle border for response areas */
     box-shadow: 0 2px 8px rgba(0,0,0,0.2);
 }
@@ -148,22 +148,22 @@ h2 { /* General sub-headings, if any are used outside response areas */
     margin-top: 0; /* Reduce margin above the response text */
 }
 
-.error-message {
+.error-message { 
     background-color: #422a2a; /* Dark red background for errors */
     color: #ff8a80; /* Lighter red text for errors */
-    border: 1px solid #b71c1c;
-    padding: 15px;
-    border-radius: 6px;
-    margin-bottom: 20px;
-    text-align: center;
+    border: 1px solid #b71c1c; 
+    padding: 15px; 
+    border-radius: 6px; 
+    margin-bottom: 20px; 
+    text-align: center; 
     white-space: pre-wrap;
 }
 
-.config-ok {
+.config-ok { 
     color: #66bb6a; /* Light green for OK status */
     font-weight: bold;
 }
-.config-nok {
+.config-nok { 
     color: #ef5350; /* Light red for NOT OK status */
     font-weight: bold;
 }
@@ -187,7 +187,7 @@ h2 { /* General sub-headings, if any are used outside response areas */
     padding: 5px;     /* Small padding to make it easier to click */
     border-radius: 50%; /* Optional: if you want a circular hover effect */
     transition: color 0.2s, background-color 0.2s;
-
+    
     position: absolute; /* Position it within the header's inner container */
     top: 15px;        /* Adjust as needed for vertical alignment with h1 */
     right: 20px;       /* Adjust as needed for spacing from the edge */
@@ -215,7 +215,7 @@ h2 { /* General sub-headings, if any are used outside response areas */
 
 .model-selector-group {
     display: flex;
-    align-items: center;
+    align-items: center; 
     gap: 10px;
     width: 100%; /* Make the group take full width of its container in the column */
     /* margin-top: 5px; */ /* Optional: if h3 margin-bottom isn't enough */
@@ -270,10 +270,10 @@ h2 { /* General sub-headings, if any are used outside response areas */
     /* display: flex; align-items: center; are still good for the inner AI label span */
     margin-right: 0;      /* Was for side-by-side, remove or ensure 0 */
     margin-bottom: 8px;   /* Space between H3 (AI Label) and the model selector group below it */
-    padding-bottom: 0;
-    border-bottom: none;
-    display: flex;
-    align-items: center;
+    padding-bottom: 0; 
+    border-bottom: none; 
+    display: flex; 
+    align-items: center; 
 }
 
 /* Styling for the model-selector-group now within the response-header */
@@ -363,8 +363,8 @@ h2 { /* General sub-headings, if any are used outside response areas */
     padding-bottom: 10px;
     margin-bottom: 15px;
 }
-.modal-content p {
-    margin: 10px 0;
+.modal-content p { 
+    margin: 10px 0; 
     color: #bbbbbb;
     font-size: 0.95em;
 }
@@ -387,11 +387,11 @@ h2 { /* General sub-headings, if any are used outside response areas */
     cursor: pointer;
 }
 
-.response-area h3 {
-    margin-top: 0;
+.response-area h3 { 
+    margin-top: 0; 
     margin-bottom: 15px;
     color: #cccccc; /* Adjusted general h3 color for dark theme consistency */
-    font-size: 18px;
+    font-size: 18px; 
     font-weight: 500;
     border-bottom: 1px solid #444;
     padding-bottom: 10px;
@@ -415,7 +415,7 @@ h2 { /* General sub-headings, if any are used outside response areas */
 
 .openai-label {
     background-color: #10a37f; /* OpenAI Teal/Green - adjust if needed, maybe #0b6e58 */
-    /* color: #ffffff; */
+    /* color: #ffffff; */ 
 }
 
 .claude-label {
@@ -423,6 +423,10 @@ h2 { /* General sub-headings, if any are used outside response areas */
     /* color: #ffffff; */
 }
 
+/* --- Utility Classes --- */
+.hidden {
+    display: none !important;
+}
 /* --- History Sidebar Styles --- */
 .sidebar {
     height: 100%; /* Full-height */

--- a/templates/index.html
+++ b/templates/index.html
@@ -45,7 +45,7 @@
 
     <div class="main-content-area container"> <!-- Main content container for responses -->
         <!-- Error display will be handled by toast notifications (step 3) -->
-        {% if error and not toast_errors_implemented_yet %}
+        {% if error and not toast_errors_implemented_yet %} 
         <!-- <div class="error-message">
             <strong>Errors:</strong><br>{{ error }}
         </div> -->
@@ -74,13 +74,16 @@
                         {% endif %}
                     </div>
                 </div>
-                {% if gemini_response and not "Error:" in gemini_response and not "An error occurred:" in gemini_response and not "API key not configured" in gemini_response %}
-                    <p>{{ gemini_response }}</p>
-                {% elif gemini_response %} {# Implies it's an error message from the client or app.py #}
-                    <p class="error-text">{{ gemini_response }}</p>
-                {% else %}
-                    <p class="placeholder-text">Response from Gemini will appear here once a prompt is submitted.</p>
-                {% endif %}
+                {# Gemini Response Content Part - New Structure #}
+                <p class="ai-response-content {% if not (gemini_response and not ("Error:" in gemini_response or "An error occurred:" in gemini_response or "API key not configured" in gemini_response or "No model specified" in gemini_response)) %}hidden{% endif %}">
+                    {{ gemini_response if (gemini_response and not ("Error:" in gemini_response or "An error occurred:" in gemini_response or "API key not configured" in gemini_response or "No model specified" in gemini_response)) else "" }}
+                </p>
+                <p class="error-text ai-response-error-text {% if not (gemini_response and ("Error:" in gemini_response or "An error occurred:" in gemini_response or "API key not configured" in gemini_response or "No model specified" in gemini_response)) %}hidden{% endif %}">
+                    {{ gemini_response if (gemini_response and ("Error:" in gemini_response or "An error occurred:" in gemini_response or "API key not configured" in gemini_response or "No model specified" in gemini_response)) else "" }}
+                </p>
+                <p class="placeholder-text {% if gemini_response %}hidden{% endif %}">
+                    Response from Gemini will appear here once a prompt is submitted.
+                </p>
             </div>
 
             {# OpenAI Response Area - Always Visible #}
@@ -105,15 +108,18 @@
                         {% endif %}
                     </div>
                 </div>
-                {% if openai_response and not "Error:" in openai_response and not "An unexpected error occurred with OpenAI:" in openai_response and not "OpenAI AuthenticationError:" in openai_response and not "OpenAI RateLimitError:" in openai_response and not "OpenAI APIConnectionError:" in openai_response and not "API key not configured" in openai_response %}
-                    <p>{{ openai_response }}</p>
-                {% elif openai_response %} {# Implies it's an error message from the client or app.py #}
-                    <p class="error-text">{{ openai_response }}</p>
-                {% else %}
-                    <p class="placeholder-text">Response from OpenAI will appear here once a prompt is submitted.</p>
-                {% endif %}
+                {# OpenAI Response Content Part - New Structure #}
+                <p class="ai-response-content {% if not (openai_response and not ("Error:" in openai_response or "An unexpected error occurred with OpenAI:" in openai_response or "OpenAI AuthenticationError:" in openai_response or "OpenAI RateLimitError:" in openai_response or "OpenAI APIConnectionError:" in openai_response or "API key not configured" in openai_response or "No model specified" in openai_response)) %}hidden{% endif %}">
+                    {{ openai_response if (openai_response and not ("Error:" in openai_response or "An unexpected error occurred with OpenAI:" in openai_response or "OpenAI AuthenticationError:" in openai_response or "OpenAI RateLimitError:" in openai_response or "OpenAI APIConnectionError:" in openai_response or "API key not configured" in openai_response or "No model specified" in openai_response)) else "" }}
+                </p>
+                <p class="error-text ai-response-error-text {% if not (openai_response and ("Error:" in openai_response or "An unexpected error occurred with OpenAI:" in openai_response or "OpenAI AuthenticationError:" in openai_response or "OpenAI RateLimitError:" in openai_response or "OpenAI APIConnectionError:" in openai_response or "API key not configured" in openai_response or "No model specified" in openai_response)) %}hidden{% endif %}">
+                    {{ openai_response if (openai_response and ("Error:" in openai_response or "An unexpected error occurred with OpenAI:" in openai_response or "OpenAI AuthenticationError:" in openai_response or "OpenAI RateLimitError:" in openai_response or "OpenAI APIConnectionError:" in openai_response or "API key not configured" in openai_response or "No model specified" in openai_response)) else "" }}
+                </p>
+                <p class="placeholder-text {% if openai_response %}hidden{% endif %}">
+                    Response from OpenAI will appear here once a prompt is submitted.
+                </p>
             </div>
-
+            
             {# Claude Response Area - Always Visible #}
             <div class="response-area" id="claudeResponseArea">
                 <div class="response-header">
@@ -137,13 +143,16 @@
                         {% endif %}
                     </div>
                 </div>
-                {% if claude_response and not "Error:" in claude_response and not "An unexpected error occurred with Anthropic:" in claude_response and not "Anthropic AuthenticationError:" in claude_response and not "Anthropic RateLimitError:" in claude_response and not "Anthropic APIConnectionError:" in claude_response and not "API key not configured" in claude_response %}
-                    <p>{{ claude_response }}</p>
-                {% elif claude_response %} {# Implies it's an error message from the client or app.py #}
-                    <p class="error-text">{{ claude_response }}</p>
-                {% else %}
-                    <p class="placeholder-text">Response from Claude will appear here once a prompt is submitted.</p>
-                {% endif %}
+                {# Claude Response Content Part - New Structure #}
+                <p class="ai-response-content {% if not (claude_response and not ("Error:" in claude_response or "An unexpected error occurred with Anthropic:" in claude_response or "Anthropic AuthenticationError:" in claude_response or "Anthropic RateLimitError:" in claude_response or "Anthropic APIConnectionError:" in claude_response or "API key not configured" in claude_response or "No model specified" in claude_response)) %}hidden{% endif %}">
+                    {{ claude_response if (claude_response and not ("Error:" in claude_response or "An unexpected error occurred with Anthropic:" in claude_response or "Anthropic AuthenticationError:" in claude_response or "Anthropic RateLimitError:" in claude_response or "Anthropic APIConnectionError:" in claude_response or "API key not configured" in claude_response or "No model specified" in claude_response)) else "" }}
+                </p>
+                <p class="error-text ai-response-error-text {% if not (claude_response and ("Error:" in claude_response or "An unexpected error occurred with Anthropic:" in claude_response or "Anthropic AuthenticationError:" in claude_response or "Anthropic RateLimitError:" in claude_response or "Anthropic APIConnectionError:" in claude_response or "API key not configured" in claude_response or "No model specified" in claude_response)) %}hidden{% endif %}">
+                    {{ claude_response if (claude_response and ("Error:" in claude_response or "An unexpected error occurred with Anthropic:" in claude_response or "Anthropic AuthenticationError:" in claude_response or "Anthropic RateLimitError:" in claude_response or "Anthropic APIConnectionError:" in claude_response or "API key not configured" in claude_response or "No model specified" in claude_response)) else "" }}
+                </p>
+                <p class="placeholder-text {% if claude_response %}hidden{% endif %}">
+                    Response from Claude will appear here once a prompt is submitted.
+                </p>
             </div>
         </div>
 
@@ -152,21 +161,21 @@
             <div class="modal-content">
                 <span class="close-modal-button">&times;</span>
                 <h4>API Configuration Status:</h4>
-                <p>Gemini ({{ gemini_model }}):
+                <p>Gemini ({{ gemini_model }}): 
                     {% if gemini_configured %}
                         <span class="config-ok">Configured</span>
                     {% else %}
                         <span class="config-nok">NOT CONFIGURED</span> (Edit <code>gemini_client.py</code>)
                     {% endif %}
                 </p>
-                <p>OpenAI ({{ openai_model }}):
+                <p>OpenAI ({{ openai_model }}): 
                     {% if openai_configured %}
                         <span class="config-ok">Configured</span>
                     {% else %}
                         <span class="config-nok">NOT CONFIGURED</span> (Edit <code>openai_client.py</code> or set <code>OPENAI_API_KEY</code> env var)
                     {% endif %}
                 </p>
-                <p>Claude ({{ claude_model }}):
+                <p>Claude ({{ claude_model }}): 
                     {% if claude_configured %}
                         <span class="config-ok">Configured</span>
                     {% else %}
@@ -185,12 +194,19 @@
     <script>
     {% if new_qna_set_to_save and prompt_text %} // Only save if flag is true and prompt exists
         document.addEventListener('DOMContentLoaded', function() {
-            // Data is directly available from Jinja variables passed to this specific render.
-            // The responses and models used are already in the template context.
+            console.log('Attempting to create qnaSetToSave object. Data from Flask:'); // DEBUG
+            console.log('Prompt for history:', {{ prompt_text | tojson }}); // DEBUG
+            console.log('Gemini response for history:', {{ gemini_response | tojson }}); // DEBUG
+            console.log('Gemini model for history:', {{ current_gemini_model | tojson }}); // DEBUG
+            console.log('OpenAI response for history:', {{ openai_response | tojson }}); // DEBUG
+            console.log('OpenAI model for history:', {{ current_openai_model | tojson }}); // DEBUG
+            console.log('Claude response for history:', {{ claude_response | tojson }}); // DEBUG
+            console.log('Claude model for history:', {{ current_claude_model | tojson }}); // DEBUG
+
             const qnaSetToSave = {
                 id: new Date().getTime().toString(), // This doesn't need tojson as it's not from Flask context directly here
                 prompt: {{ prompt_text | tojson }},
-                gemini_response: {{ gemini_response | tojson }},
+                gemini_response: {{ gemini_response | tojson }}, 
                 gemini_model: {{ current_gemini_model | tojson }},
                 openai_response: {{ openai_response | tojson }},
                 openai_model: {{ current_openai_model | tojson }},
@@ -198,13 +214,16 @@
                 claude_model: {{ current_claude_model | tojson }},
                 timestamp: new Date().toISOString() // This is JS-generated, no filter needed
             };
-
+            console.log('Constructed qnaSetToSave:', qnaSetToSave); // DEBUG
+            
             if (qnaSetToSave.prompt) {
+                console.log('Calling saveQASet with constructed object.'); // DEBUG
                 saveQASet(qnaSetToSave); // Assumes saveQASet is globally available from script.js
-
+                
                 const historySidebar = document.getElementById('historySidebar');
                 if (historySidebar && historySidebar.classList.contains('open')) {
                     if (typeof renderHistorySidebar === 'function') { // Check if function exists
+                        console.log('Calling renderHistorySidebar after saveQASet from index.html script.'); // DEBUG
                         renderHistorySidebar();
                     }
                 }


### PR DESCRIPTION
…gic.

This commit addresses an issue where AI response areas would appear blank when loading a historical Q&A set on initial page load, even if the history item contained valid response data.

Key changes:
- Updated `templates/index.html`:
    - Each AI response area (Gemini, OpenAI, Claude) now consistently renders three distinct paragraph elements: - `.ai-response-content` (for successful AI responses) - `.ai-response-error-text` (for errors from AI clients) - `.placeholder-text` (for initial placeholder)
    - Jinja logic now sets the initial text content for these paragraphs and conditionally applies a `.hidden` class to manage visibility, ensuring all three <p> tags are always in the DOM.
- Updated `displayResponseInArea` function in `static/script.js`:
    - Now targets these three specific paragraph elements within each response area.
    - Manages their content and visibility by adding/removing the `.hidden` class based on whether the `responseText` (from history or a live query) is a valid AI response, a client-generated error string, or null/empty (in which case the placeholder is shown).
    - Includes more robust heuristics for identifying error strings.
- Added a `.hidden { display: none !important; }` utility class to `static/style.css` for use by the JavaScript logic.

These changes ensure that historical Q&A data is correctly and reliably displayed in the respective AI response areas when loaded from the history sidebar, including on initial page load if a history item is active.